### PR TITLE
fix: resolve popup authentication failures after Vue 3 upgrade

### DIFF
--- a/app/components/BaseWebView.vue
+++ b/app/components/BaseWebView.vue
@@ -11,6 +11,7 @@
     @loadFinished="onLoadFinished"
     @loadError="onLoadError"
     @shouldOverrideUrlLoading="onShouldOverrideUrlLoading"
+    @titleChanged="onTitleChanged"
   />
 </template>
 
@@ -74,9 +75,6 @@ export default {
       client.initWithComponent({
         setProgress: (progress) => {
           this.$emit('progress', progress);
-        },
-        setPageTitle: (title) => {
-          this.$emit('title-changed', title);
         },
         showPopup: (resultMsg) => {
           this.$emit('show-popup', { transport: resultMsg });
@@ -170,6 +168,10 @@ export default {
       }
       this.$emit('should-override-url-loading', args);
       return args;
+    },
+
+    onTitleChanged(args) {
+      this.$emit('page-title-changed', args.title);
     },
 
     /**

--- a/app/components/BaseWebView.vue
+++ b/app/components/BaseWebView.vue
@@ -76,8 +76,8 @@ export default {
         setProgress: (progress) => {
           this.$emit('progress', progress);
         },
-        showPopup: (resultMsg) => {
-          this.$emit('show-popup', { transport: resultMsg });
+        showPopup: (popupData) => {
+          this.$emit('show-popup', popupData);
         },
         closePopup: () => {
           this.$emit('close-popup');

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -89,7 +89,7 @@ export default {
         isVisible: false,
         props: {
           url: null,
-          transport: null
+          transportId: null
         }
       },
       sliding: {
@@ -151,17 +151,17 @@ export default {
       ]);
     },
 
-    handlePopup({ url, transport }) {
+    handlePopup(data) {
       this.popup = {
         isVisible: true,
-        props: { url, transport }
+        props: data
       };
     },
 
     handlePopupClose() {
       this.popup = {
         isVisible: false,
-        props: { url: null, transport: null }
+        props: { url: null, transportId: null }
       };
     },
 

--- a/app/components/PopupWebView.vue
+++ b/app/components/PopupWebView.vue
@@ -23,7 +23,7 @@
             class="webview-container"
             :src="url"
             @webview-loaded="onWebViewLoaded"
-            @title-changed="updatePageTitle"
+            @page-title-changed="updatePageTitle"
             @external-url="handleExternalUrl"
             @progress="updateProgress"
             @close-popup="closePopup"
@@ -45,6 +45,7 @@
 
 <script>
 import BaseWebView from './BaseWebView.vue';
+import { markRaw } from 'vue';
 
 export default {
   name: 'PopupWebView',
@@ -104,10 +105,10 @@ export default {
 
     onWebViewLoaded({ webview }) {
       if (this.transport) {
-        const transport = this.transport.obj;
-        transport?.setWebView(webview.android);
-
         try {
+          const transport = this.transport.obj;
+          transport?.setWebView(webview.android);
+
           if (transport && transport.getWebView()) {
             this.transport.sendToTarget();
           }

--- a/app/components/PopupWebView.vue
+++ b/app/components/PopupWebView.vue
@@ -45,7 +45,7 @@
 
 <script>
 import BaseWebView from './BaseWebView.vue';
-import { markRaw } from 'vue';
+import { transportManager } from '@/utils/webview/transport-manager';
 
 export default {
   name: 'PopupWebView',
@@ -59,8 +59,8 @@ export default {
       type: String,
       default: ''
     },
-    transport: {
-      type: Object,
+    transportId: {
+      type: String,
       default: null
     }
   },
@@ -100,20 +100,17 @@ export default {
     },
 
     closePopup() {
+      if (this.transportId) {
+        transportManager.cleanupTransport(this.transportId);
+      }
       this.$emit('close');
     },
 
     onWebViewLoaded({ webview }) {
-      if (this.transport) {
-        try {
-          const transport = this.transport.obj;
-          transport?.setWebView(webview.android);
-
-          if (transport && transport.getWebView()) {
-            this.transport.sendToTarget();
-          }
-        } catch (error) {
-          console.error('Error sending transport message:', error);
+      if (this.transportId) {
+        const success = transportManager.initializeTransport(this.transportId, webview);
+        if (!success) {
+          console.error('Failed to initialize transport:', this.transportId);
         }
       }
     }

--- a/app/utils/webview/base-chrome-client.js
+++ b/app/utils/webview/base-chrome-client.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2024-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { isAndroid } from "@nativescript/core";
+import {markRaw} from "vue";
 
 /**
  * WebView chrome client implementation
@@ -15,12 +16,6 @@ export const BaseWebChromeClient = isAndroid ? android.webkit.WebChromeClient.ex
   onProgressChanged: function(view, progress) {
     if (this.component?.setProgress) {
       this.component.setProgress(progress);
-    }
-  },
-
-  onReceivedTitle: function(view, title) {
-    if (this.component?.setPageTitle) {
-      this.component.setPageTitle(title);
     }
   },
 
@@ -39,7 +34,8 @@ export const BaseWebChromeClient = isAndroid ? android.webkit.WebChromeClient.ex
     if (!isUserGesture) return false;
 
     if (this.component?.showPopup) {
-      this.component.showPopup(resultMsg);
+      const frozenResultMsg = markRaw(resultMsg);
+      this.component.showPopup(frozenResultMsg);
       return true;
     }
     return false;

--- a/app/utils/webview/base-chrome-client.js
+++ b/app/utils/webview/base-chrome-client.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2024-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { isAndroid } from "@nativescript/core";
-import {markRaw} from "vue";
+import { transportManager } from "./transport-manager";
 
 /**
  * WebView chrome client implementation
@@ -34,8 +34,8 @@ export const BaseWebChromeClient = isAndroid ? android.webkit.WebChromeClient.ex
     if (!isUserGesture) return false;
 
     if (this.component?.showPopup) {
-      const frozenResultMsg = markRaw(resultMsg);
-      this.component.showPopup(frozenResultMsg);
+      const popupData = transportManager.storeTransport(resultMsg);
+      this.component.showPopup(popupData);
       return true;
     }
     return false;

--- a/app/utils/webview/transport-manager.js
+++ b/app/utils/webview/transport-manager.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+
+/**
+ * Transport Manager - Isolates native transport objects from Vue reactivity
+ */
+
+class TransportManager {
+  constructor() {
+    this.transports = new Map();
+    this.nextId = 1;
+  }
+
+  /**
+   * Stores transport object and returns ID for Vue
+   */
+  storeTransport(resultMsg) {
+    const transportId = `transport_${this.nextId++}`;
+
+    this.transports.set(transportId, {
+      obj: resultMsg.obj,
+      sendToTarget: () => resultMsg.sendToTarget()
+    });
+
+    // Return only ID for Vue, URL empty because content loads via transport
+    return {
+      transportId,
+      url: ''
+    };
+  }
+
+  /**
+   * Initializes transport for WebView
+   */
+  initializeTransport(transportId, webview) {
+    const transport = this.transports.get(transportId);
+    if (!transport) {
+      console.error('Transport not found:', transportId);
+      return false;
+    }
+
+    try {
+      transport.obj?.setWebView(webview.android);
+
+      if (transport.obj && transport.obj.getWebView()) {
+        transport.sendToTarget();
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('Error initializing transport:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Cleans up transport when popup closes
+   */
+  cleanupTransport(transportId) {
+    this.transports.delete(transportId);
+  }
+}
+
+export const transportManager = new TransportManager();


### PR DESCRIPTION
Fixes popup-based authentication breaking after Vue 3 migration due to reactivity system conflicts with native Android WebView objects.

- Add TransportManager to isolate native transport objects from Vue reactivity
- Add native (`ui-webview` plugin) titleChanged event handler in BaseWebView to extract title strings instead of custom implementation