### PR TITLE
swipeable fullscreen mode

### DIFF
--- a/app/app.scss
+++ b/app/app.scss
@@ -133,6 +133,25 @@ $radius-full: 9999; // For circular elements
   box-shadow: 0 2 4 rgba(0, 0, 0, 0.05);
 }
 
+// Floating action button
+.fab {
+  width: 50;
+  height: 50;
+  vertical-align: bottom;
+  border-radius: $radius-full;
+  background-color: rgba(255, 255, 255, 0.1);
+  ripple-color: $ripple;
+
+  .fa {
+    color: white;
+    font-size: 18;
+    horizontal-alignment: center;
+    vertical-alignment: center;
+    margin-top: -50;
+    height: 50;
+  }
+}
+
 .btn-text {
   color: $primary;
   font-size: $font-size;

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -226,7 +226,8 @@ export default {
             break;
           case 'ui/setKeyboardOpen':
           case 'ui/setScreenSafeArea':
-          case 'ui/setLayoutDimensions': {
+          case 'ui/setLayoutDimensions':
+          case 'ui/setPanelPosition': {
             const wsa = this.$store.getters['ui/webviewSafeArea'];
             await webview.executeJavaScript(
               setSafeAreaInsets(wsa.top, wsa.bottom, wsa.left, wsa.right)

--- a/app/components/BottomPanel/BottomSheetPanel.vue
+++ b/app/components/BottomPanel/BottomSheetPanel.vue
@@ -203,9 +203,7 @@ export default {
     },
 
     /**
-     * Steps for bottom sheet positions
-     * When keyboard is closed: [BOTTOM, MIDDLE, TOP]
-     * When keyboard is open: [HIDDEN, BOTTOM, MIDDLE, TOP]
+     * Steps for bottom sheet positions: [HIDDEN, BOTTOM, MIDDLE, TOP]
      */
     steps() {
       const height = this.screenHeight || 800;
@@ -214,12 +212,7 @@ export default {
       // Bottom step extends behind the nav bar so panel content stays above it
       const bottomStep = this.PANEL_CLOSED_HEIGHT + this.navBarHeight;
 
-      // Include HIDDEN position (0) only when keyboard is open
-      if (!this.isVisible) {
-        return [0, bottomStep, middlePosition, topPosition];
-      }
-
-      return [bottomStep, middlePosition, topPosition];
+      return [0, bottomStep, middlePosition, topPosition];
     },
 
     /**
@@ -248,8 +241,7 @@ export default {
       if (!newValue) {
         // Switched to non-map pane - collapse panel to BOTTOM position
         this.$nextTick(() => {
-          // BOTTOM position index depends on whether keyboard is open
-          this.stepIndexLocal = this.isVisible ? 0 : 1;
+          this.stepIndexLocal = 1; // BOTTOM
         });
       }
     },
@@ -259,18 +251,15 @@ export default {
      */
     isVisible(newValue, oldValue) {
       if (!newValue && oldValue) {
-        // Keyboard opened - steps array now includes HIDDEN at index 0
-        // Current panel position shifts +1 in the array
-        // Hide panel to HIDDEN position (index 0)
+        // Keyboard opened - hide panel
         this.$nextTick(() => {
           this.stepIndexLocal = 0; // HIDDEN
         });
       } else if (newValue && !oldValue) {
-        // Keyboard closed - steps array no longer includes HIDDEN
-        // Restore panel to previous position, adjusting index -1
+        // Keyboard closed - restore panel to previous position
         if (this.lastStepIndex > 0) {
           this.$nextTick(() => {
-            this.stepIndexLocal = this.lastStepIndex - 1;
+            this.stepIndexLocal = this.lastStepIndex;
           });
         }
       }
@@ -283,40 +272,24 @@ export default {
       // Validate index
       if (newIndex === undefined || newIndex === null) return;
 
-      // Determine position names based on whether HIDDEN is included
-      let positions, isOpen;
+      // Steps: [HIDDEN, BOTTOM, MIDDLE, TOP]
+      const positions = ['HIDDEN', 'BOTTOM', 'MIDDLE', 'TOP'];
 
-      if (!this.isVisible) {
-        // Keyboard open: [HIDDEN, BOTTOM, MIDDLE, TOP]
-        positions = ['HIDDEN', 'BOTTOM', 'MIDDLE', 'TOP'];
-        // Save position if not HIDDEN
-        if (newIndex > 0) {
-          this.lastStepIndex = newIndex;
-        }
-        // Panel is open if index > 1 (MIDDLE or TOP)
-        isOpen = newIndex > 1;
-      } else {
-        // Keyboard closed: [BOTTOM, MIDDLE, TOP]
-        positions = ['BOTTOM', 'MIDDLE', 'TOP'];
-        // Always save position
+      // Save position if not HIDDEN
+      if (newIndex > 0) {
         this.lastStepIndex = newIndex;
-        // Panel is open if index > 0 (MIDDLE or TOP)
-        isOpen = newIndex > 0;
       }
 
       const position = positions[newIndex] || positions[0];
-
-      // Get step value
       const stepValue = this.steps && this.steps[newIndex] !== undefined ? this.steps[newIndex] : 0;
 
-      // Update store
       this.setPanelPosition({
         position: position,
         value: stepValue,
       });
 
-      // Update open state
-      this.setPanelOpenState(isOpen);
+      // Panel is open if MIDDLE or TOP
+      this.setPanelOpenState(newIndex > 1);
     },
 
     /**
@@ -364,11 +337,8 @@ export default {
       // If panel is closed, open with the selected button
       if (!this.isPanelOpen) {
         this.switchPanel(button);
-        // Trigger panel to open by updating stepIndexLocal to MIDDLE
-        // The BottomSheet component will detect the change and emit stepIndexChange event
         this.$nextTick(() => {
-          // MIDDLE position index depends on whether keyboard is open
-          this.stepIndexLocal = this.isVisible ? 1 : 2;
+          this.stepIndexLocal = 2; // MIDDLE
         });
         return;
       }
@@ -376,10 +346,8 @@ export default {
       // If clicking the same button again, close panel to BOTTOM
       if (button === this.activeButton) {
         this.setActivePanel(null);
-        // Close panel to BOTTOM position
         this.$nextTick(() => {
-          // BOTTOM position index depends on whether keyboard is open
-          this.stepIndexLocal = this.isVisible ? 0 : 1;
+          this.stepIndexLocal = 1; // BOTTOM
         });
         return;
       }
@@ -420,12 +388,10 @@ export default {
      * Handle open panel command
      */
     handleOpenCommand() {
-      const middleIndex = this.isVisible ? 1 : 2;
-      if (this.stepIndexLocal >= middleIndex) return; // Already open
+      if (this.stepIndexLocal >= 2) return; // Already open (MIDDLE or TOP)
 
-      // Open to middle position
       this.$nextTick(() => {
-        this.stepIndexLocal = middleIndex; // MIDDLE
+        this.stepIndexLocal = 2; // MIDDLE
       });
 
       // Set default panel if none is active
@@ -438,12 +404,10 @@ export default {
      * Handle close panel command
      */
     handleCloseCommand() {
-      const bottomIndex = this.isVisible ? 0 : 1;
-      if (this.stepIndexLocal === bottomIndex) return; // Already at BOTTOM
+      if (this.stepIndexLocal === 1) return; // Already at BOTTOM
 
-      // Close panel to BOTTOM position
       this.$nextTick(() => {
-        this.stepIndexLocal = bottomIndex; // BOTTOM
+        this.stepIndexLocal = 1; // BOTTOM
       });
     },
 
@@ -461,8 +425,7 @@ export default {
     this._activeButton = this.storedActivePanel || 'quick';
 
     // Initialize panel in BOTTOM position (visible but closed)
-    // Index 0 when keyboard closed (no HIDDEN), index 1 when keyboard open (with HIDDEN)
-    this.stepIndexLocal = this.isVisible ? 0 : 1;
+    this.stepIndexLocal = 1; // BOTTOM
 
     // Listen for layout changes
     this.removeLayoutListener = layoutService.addLayoutChangeListener(this.handleLayoutChange);

--- a/app/components/DebugConsole/index.vue
+++ b/app/components/DebugConsole/index.vue
@@ -1,7 +1,11 @@
-// Copyright (C) 2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+// Copyright (C) 2025-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 <template>
-  <GridLayout rows="*, auto" class="debug-console" :style="{ 'padding-bottom': keyboardPaddingBottom }">
+  <GridLayout
+    rows="*, auto"
+    class="debug-console"
+    :style="{ 'padding-bottom': keyboardPaddingBottom }"
+  >
     <!-- Logs list -->
     <CollectionView
       ref="logsList"
@@ -42,7 +46,7 @@
 
     <MDRipple
       v-show="!isAtBottom && showControls"
-      class="scroll-bottom-button"
+      class="fab scroll-bottom-button"
       @tap="scrollToBottom"
     >
       <Label
@@ -57,7 +61,11 @@
 
 <script>
 import { mapState, mapActions } from 'vuex';
-import { performanceOptimizationMixin, optimizeMapState, Cache } from '~/utils/performance-optimization';
+import {
+  performanceOptimizationMixin,
+  optimizeMapState,
+  Cache,
+} from '~/utils/performance-optimization';
 import logFormattingMixin from './mixins/logFormatting';
 import { copyToClipboard } from '@/utils/clipboard';
 import ControlsPanel from './ControlsPanel.vue';
@@ -65,27 +73,24 @@ import { isAndroid } from '@nativescript/core';
 
 export default {
   components: {
-    ControlsPanel
+    ControlsPanel,
   },
 
-  mixins: [
-    performanceOptimizationMixin,
-    logFormattingMixin
-  ],
+  mixins: [performanceOptimizationMixin, logFormattingMixin],
 
   props: {
     isVisible: {
       type: Boolean,
-      default: false
+      default: false,
     },
     isKeyboardOpen: {
       type: Boolean,
-      default: false
+      default: false,
     },
     keyboardHeight: {
       type: Number,
-      default: 0
-    }
+      default: 0,
+    },
   },
 
   data() {
@@ -93,13 +98,13 @@ export default {
       command: '',
       isAtBottom: true,
       showControls: false, // Controls UI elements visibility
-      logsVisible: false,  // Controls whether logs should be shown or not
+      logsVisible: false, // Controls whether logs should be shown or not
 
       _logFormattingCache: new Cache(200, 600000), // Cache formatted logs for 10 minutes
       _displayLogsCache: null,
       _lastLogsHash: null,
-      _collectionView: null
-    }
+      _collectionView: null,
+    };
   },
 
   computed: {
@@ -117,11 +122,13 @@ export default {
       return Math.max(0, this.keyboardHeight - safeAreaBottom);
     },
 
-    ...mapState(optimizeMapState({
-      logs: 'debug.logs',
-      commandHistory: 'debug.commandHistory',
-      historyPosition: 'debug.historyPosition'
-    })),
+    ...mapState(
+      optimizeMapState({
+        logs: 'debug.logs',
+        commandHistory: 'debug.commandHistory',
+        historyPosition: 'debug.historyPosition',
+      })
+    ),
 
     // Display logs only when both component is visible and logs should be shown
     displayLogs() {
@@ -130,7 +137,12 @@ export default {
       }
 
       // Create hash of logs for cache invalidation
-      const logsHash = this.logs.length + '-' + (this.logs[0]?.timestamp || 0) + '-' + (this.logs[this.logs.length - 1]?.timestamp || 0);
+      const logsHash =
+        this.logs.length +
+        '-' +
+        (this.logs[0]?.timestamp || 0) +
+        '-' +
+        (this.logs[this.logs.length - 1]?.timestamp || 0);
 
       // Return cached result if logs haven't changed
       if (this._lastLogsHash === logsHash && this._displayLogsCache) {
@@ -142,7 +154,7 @@ export default {
       this._lastLogsHash = logsHash;
 
       return this._displayLogsCache;
-    }
+    },
   },
 
   watch: {
@@ -184,15 +196,11 @@ export default {
           this.scrollToBottom();
         });
       }
-    }
+    },
   },
 
   methods: {
-    ...mapActions('debug', [
-      'clearLogs',
-      'addCommand',
-      'navigateHistory'
-    ]),
+    ...mapActions('debug', ['clearLogs', 'addCommand', 'navigateHistory']),
 
     // Handle executed command from ControlsPanel
     onCommandExecuted(cmdString) {
@@ -243,7 +251,7 @@ export default {
 
         this.isAtBottom = isLastVisible || isSecondToLastVisible;
       } catch (e) {
-        console.error("Error checking scroll position:", e);
+        console.error('Error checking scroll position:', e);
         this.isAtBottom = true;
       }
     },
@@ -260,7 +268,7 @@ export default {
         this._collectionView.scrollToIndex(lastIndex, true);
         this.isAtBottom = true;
       } catch (e) {
-        console.error("Error scrolling to bottom:", e);
+        console.error('Error scrolling to bottom:', e);
       }
     },
 
@@ -277,10 +285,10 @@ export default {
     // Copy log text to clipboard on long press
     async copyLogToClipboard(item) {
       const fullText = this.getFullLogText(item);
-      await copyToClipboard(fullText, "Log copied to clipboard");
+      await copyToClipboard(fullText, 'Log copied to clipboard');
     },
   },
-}
+};
 </script>
 
 <style scoped lang="scss">
@@ -358,20 +366,7 @@ export default {
 }
 
 .scroll-bottom-button {
-  width: 50;
-  height: 50;
-  border-radius: $radius-full;
-  background-color: rgba(255, 255, 255, 0.1);
-  color: white;
-  font-size: 18;
-  vertical-align: bottom;
   horizontal-align: right;
   margin: $spacing-l $spacing-m;
-  text-align: center;
-}
-
-.scroll-bottom-button .fa {
-  margin-top: -50;
-  height: 50;
 }
 </style>

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -55,7 +55,7 @@
         <!-- Restore panel button (visible when panel is hidden) -->
         <MDRipple
           v-if="isPanelHidden && !isDebugActive"
-          class="restore-panel-button"
+          class="fab restore-panel-button"
           :style="{ marginBottom: navBarHeight + 16, marginLeft: safeAreaLeftInset + 16 }"
           @loaded="onRestoreButtonLoaded"
           @tap="restorePanel"
@@ -493,20 +493,7 @@ export default {
 }
 
 .restore-panel-button {
-  width: 42;
-  height: 42;
-  border-radius: $radius-full;
-  background-color: rgba(0, 0, 0, 0.4);
-  vertical-alignment: bottom;
   horizontal-alignment: left;
-  margin-left: 16;
   z-index: 1000;
-}
-
-.restore-panel-button .fa {
-  color: white;
-  font-size: 16;
-  margin-top: -42;
-  height: 42;
 }
 </style>

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -357,6 +357,13 @@ export default {
           return;
         }
 
+        // If panel is hidden, restore it
+        if (this.isPanelHidden) {
+          this.restorePanel();
+          args.cancel = true;
+          return;
+        }
+
         this.$store.dispatch('navigation/setCurrentPane', 'map');
         args.cancel = true;
       });

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -52,6 +52,22 @@
           class="map-state-bar-overlay"
         />
 
+        <!-- Restore panel button (visible when panel is hidden) -->
+        <MDRipple
+          v-if="isPanelHidden && !isDebugActive"
+          class="restore-panel-button"
+          :style="{ marginBottom: navBarHeight + 16, marginLeft: safeAreaLeftInset + 16 }"
+          @loaded="onRestoreButtonLoaded"
+          @tap="restorePanel"
+        >
+          <Label
+            class="fa"
+            :text="$filters.fonticon('fa-chevron-up')"
+            horizontalAlignment="center"
+            verticalAlignment="center"
+          />
+        </MDRipple>
+
         <!-- Debug Console -->
         <AbsoluteLayout v-show="isDebugActive" class="page">
           <DebugConsole
@@ -262,6 +278,22 @@ export default {
       this.bottomSheetInstance = bottomSheet;
     },
 
+    onRestoreButtonLoaded(args) {
+      const btn = args.object;
+      btn.translateY = 60;
+      btn.opacity = 0;
+      btn.animate({
+        translate: { x: 0, y: 0 },
+        opacity: 1,
+        duration: 300,
+        curve: CoreTypes.AnimationCurve.easeOut,
+      });
+    },
+
+    restorePanel() {
+      this.$store.dispatch('ui/closePanel');
+    },
+
     // Handle console logs from AppWebView
     onConsoleLog(logData) {
       this.$store.dispatch('debug/addLog', logData);
@@ -458,5 +490,23 @@ export default {
 
 .map-state-bar-overlay {
   z-index: 1000;
+}
+
+.restore-panel-button {
+  width: 42;
+  height: 42;
+  border-radius: $radius-full;
+  background-color: rgba(0, 0, 0, 0.4);
+  vertical-alignment: bottom;
+  horizontal-alignment: left;
+  margin-left: 16;
+  z-index: 1000;
+}
+
+.restore-panel-button .fa {
+  color: white;
+  font-size: 16;
+  margin-top: -42;
+  height: 42;
 }
 </style>

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -40,7 +40,8 @@
 
         <!-- MapStateBar overlay - positioned at bottom, above BottomSheet -->
         <MapStateBar
-          v-show="sliding.isVisible && !isDebugActive"
+          ref="mapStateBar"
+          v-show="!isDebugActive"
           :bottomSheetRef="bottomSheetInstance"
           verticalAlignment="bottom"
           horizontalAlignment="left"
@@ -67,7 +68,14 @@
 </template>
 
 <script>
-import { AndroidApplication, Application, Frame, isAndroid, isIOS } from '@nativescript/core';
+import {
+  AndroidApplication,
+  Application,
+  CoreTypes,
+  Frame,
+  isAndroid,
+  isIOS,
+} from '@nativescript/core';
 import { keyboardOpening } from '@bezlepkin/nativescript-keyboard-opening';
 import { layoutService } from '~/utils/layout-service';
 import UserLocation from '@/utils/user-location';
@@ -127,6 +135,9 @@ export default {
     isDebugActive() {
       return this.$store.state.ui.isDebugActive;
     },
+    isPanelHidden() {
+      return this.$store.state.ui.panelState.position === 'HIDDEN';
+    },
     safeAreaLeftInset() {
       return this.$store.state.ui.screenSafeArea.left;
     },
@@ -145,11 +156,39 @@ export default {
       if (isAndroid && this.isKeyboardOpen) {
         return this.keyboardHeight;
       }
+      if (this.isPanelHidden) {
+        return 0;
+      }
       return this.layout.bottomPadding + this.navBarHeight;
     },
   },
 
+  watch: {
+    isPanelHidden(hidden) {
+      this.updateMapStateBarVisibility(hidden, true);
+    },
+  },
+
   methods: {
+    updateMapStateBarVisibility(hidden, animate) {
+      const bar = this.$refs.mapStateBar?.$el?.nativeView;
+      if (!bar) return;
+
+      const bottomInset = this.navBarHeight || this.$store.state.ui.screenSafeArea.bottom;
+      const slideDistance = this.mapStateBarHeight + bottomInset;
+      const y = hidden ? slideDistance : 0;
+
+      if (animate) {
+        bar.animate({
+          translate: { x: 0, y },
+          duration: 200,
+          curve: CoreTypes.AnimationCurve.easeOut,
+        });
+      } else {
+        bar.translateY = y;
+      }
+    },
+
     /**
      * Called when RootLayout changes size
      * This captures real available space including keyboard state
@@ -173,6 +212,11 @@ export default {
      */
     handleLayoutChanged(args) {
       const { dimensions } = args;
+
+      // Re-apply MapStateBar position after layout change
+      if (this.isPanelHidden) {
+        this.$nextTick(() => this.updateMapStateBarVisibility(true, false));
+      }
 
       // Update local layout state
       this.layout = {

--- a/app/store/modules/ui.js
+++ b/app/store/modules/ui.js
@@ -50,12 +50,23 @@ export const ui = {
 
     // Computed WebView safe area insets: screen insets adjusted for panel layout.
     // When keyboard is open, bottom is 0: WebView is already above keyboard, no panel to avoid.
-    webviewSafeArea: (state, getters) => ({
-      top: state.screenSafeArea.top,
-      bottom: state.isKeyboardOpen ? 0 : getters.webViewBottomInset,
-      left: state.screenSafeArea.left,
-      right: state.screenSafeArea.right,
-    }),
+    // When panel is hidden, bottom equals system nav bar height
+    webviewSafeArea: (state, getters) => {
+      let bottom;
+      if (state.isKeyboardOpen) {
+        bottom = 0;
+      } else if (state.panelState.position === 'HIDDEN') {
+        bottom = state.screenSafeArea.bottom;
+      } else {
+        bottom = getters.webViewBottomInset;
+      }
+      return {
+        top: state.screenSafeArea.top,
+        bottom,
+        left: state.screenSafeArea.left,
+        right: state.screenSafeArea.right,
+      };
+    },
   },
 
   mutations: {

--- a/patches/@nativescript-community+gesturehandler+2.0.43.patch
+++ b/patches/@nativescript-community+gesturehandler+2.0.43.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/@nativescript-community/gesturehandler/gesturehandler.ios.js b/node_modules/@nativescript-community/gesturehandler/gesturehandler.ios.js
+index 44c96f8..510aedb 100644
+--- a/node_modules/@nativescript-community/gesturehandler/gesturehandler.ios.js
++++ b/node_modules/@nativescript-community/gesturehandler/gesturehandler.ios.js
+@@ -395,6 +395,23 @@ export class Manager extends ManagerBase {
+             dispose: onDispose
+         });
+     }
++    findRootView(view) {
++        if (view instanceof GestureRootView) {
++            return view;
++        }
++        let parent = view.parent;
++        while (parent) {
++            if (parent instanceof GestureRootView) {
++                return parent;
++            }
++            parent = parent.parent;
++        }
++        const page = view.page;
++        return page;
++    }
++    findRegistry(view) {
++        return this.findRootView(view)?.registry;
++    }
+     detachGestureHandler(handlerTag, view) {
+         if (view.nativeView) {
+             this.manager.dropGestureHandler(handlerTag);


### PR DESCRIPTION
- Fix bottom panel swipe gestures breaking on iOS (missing `findRootView` in gesture handler)
- Allow swiping panel down to enter fullscreen mode (hides panel and MapStateBar)
- Add floating button to restore panel from fullscreen