### PR TITLE
Fix WebView destroy race condition on Android

### DIFF
--- a/app/components/BaseWebView.vue
+++ b/app/components/BaseWebView.vue
@@ -269,17 +269,11 @@ export default {
           if (isAndroid) {
             const androidWebView = this.webViewInstance.android;
             if (androidWebView) {
-              androidWebView.stopLoading(); // Stop any ongoing loads
-              androidWebView.clearHistory(); // Clear navigation history
-              androidWebView.clearCache(true); // Clear cache
-              androidWebView.clearFormData(); // Clear form data
-              androidWebView.clearMatches(); // Clear search matches
-              androidWebView.loadUrl('about:blank'); // Clear all content
-
               try {
+                androidWebView.stopLoading();
                 androidWebView.setWebViewClient(null);
                 androidWebView.setWebChromeClient(null);
-                androidWebView.destroy(); // Destroy the WebView
+                androidWebView.destroy();
               } catch (destroyError) {
                 console.error('Error during WebView destroy:', destroyError);
               }


### PR DESCRIPTION
`cleanupWebView()` called `loadUrl('about:blank')` before `destroy()`. Since `loadUrl` is non-blocking, Chromium dispatched an async rendering task - then the code immediately nulled the clients and destroyed the WebView. When the async task completed and tried to fire a JNI callback into the already-destroyed instance, ART aborted with SIGABRT.

Fix: replace the sequence with `stopLoading()` -> null clients -> `destroy()`.
After `stopLoading()` no new async tasks are dispatched, making the destroy race-free.