### PR TITLE
fix: provide stable name for WebChromeClient Android extend

### DIFF
--- a/app/utils/webview/base-chrome-client.js
+++ b/app/utils/webview/base-chrome-client.js
@@ -8,7 +8,7 @@ import { transportManager } from './transport-manager';
  * iOS popup handling is done natively by ui-webview patch
  */
 export const BaseWebChromeClient = isAndroid
-  ? android.webkit.WebChromeClient.extend({
+  ? android.webkit.WebChromeClient.extend('IITCBaseWebChromeClient', {
       init: function () {},
 
       initWithComponent: function (component) {


### PR DESCRIPTION
Without an explicit name, NativeScript derives the Java class name from the bundle file position (e.g. WebChromeClient_bundle_5613_36_). After each rebuild Webpack shifts line numbers, the cached DEX entry becomes
stale, and Android throws ClassNotFoundException on app start. The only workaround was clearing app data.

Passing a fixed name as the first argument to extend() breaks the dependency on bundle position so the DEX cache stays valid across rebuilds.