### PR TITLE
fix: strip NUL bytes from plugin code before installation

### DIFF
--- a/app/utils/plugin-installer.js
+++ b/app/utils/plugin-installer.js
@@ -26,6 +26,9 @@ export async function downloadPlugin(url) {
  * @throws {Error} if code is not a valid userscript
  */
 export async function confirmAndInstallPlugin(code, filename) {
+  // Strip NUL bytes from FAT32/exFAT cluster-padding when reading files via Android ContentResolver
+  code = code.replaceAll('\x00', '');
+
   const meta = parseMeta(code);
   if (!meta || !meta.name) {
     throw new Error('Invalid userscript. The file must contain a valid ==UserScript== header.');

--- a/patches/lib-iitc-manager+1.13.1.patch
+++ b/patches/lib-iitc-manager+1.13.1.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/lib-iitc-manager/dist/wrapper.js b/node_modules/lib-iitc-manager/dist/wrapper.js
+index 4e7fb4f..b58cdcc 100644
+--- a/node_modules/lib-iitc-manager/dist/wrapper.js
++++ b/node_modules/lib-iitc-manager/dist/wrapper.js
+@@ -27,12 +27,14 @@ export function wrapPluginCode(plugin, source_url_prefix = '') {
+     const data_key = getPluginHash(uid);
+     const meta = { ...plugin };
+     delete meta.code;
++    // Strip NUL bytes
++    const pluginCode = plugin.code.replaceAll('\x00', '');
+     const code = [
+         '((GM)=>{',
+         GM_V3_BINDINGS,
+         '\n',
+-        plugin.code,
+-        plugin.code.endsWith('\n') ? '' : '\n',
++        pluginCode,
++        pluginCode.endsWith('\n') ? '' : '\n',
+         `})(GM(${JSON.stringify({ data_key, meta })}))`,
+     ].join('');
+     return appendSourceUrl({ code, name: meta.name || uid || 'plugin', prefix: source_url_prefix });


### PR DESCRIPTION
Files read via Android ContentResolver from FAT32/exFAT storage can contain trailing NUL bytes due to cluster-padding. When the plugin is wrapped with `wrapPluginCode()`, these bytes end up between the plugin body and the closing `})(GM(...))` call, causing SyntaxError in the WebView's JS engine.

Strip NUL bytes at install time in confirmAndInstallPlugin(). The same fix is applied in lib-iitc-manager.
