### PR TITLE
fix: prevent zoom on orientation change in Android WebView

### DIFF
--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -115,6 +115,9 @@ export default {
         await injectBridgeIITC(this.webview);
         await injectDebugBridge(this.webview);
 
+        // Inject early so styles are active before IITC rewrites document.head
+        await injectCustomStyles(this.webview);
+
         // Mark this URL as processed
         this.lastInjectedUrl = arg.url;
 
@@ -176,6 +179,7 @@ export default {
             break;
           case 'ui/iitcBootFinished': {
             await installFileChooserOverride(webview);
+            // Re-inject after IITC boot since document.head was replaced
             await injectCustomStyles(webview);
             // Set initial safe area insets after IITC loads
             const wsa = this.$store.getters['ui/webviewSafeArea'];

--- a/app/utils/webview/webview-settings.js
+++ b/app/utils/webview/webview-settings.js
@@ -18,6 +18,7 @@ export function applyWebViewSettings(webview, fakeUserAgent = false) {
     settings.setJavaScriptEnabled(true);
     settings.setDomStorageEnabled(true);
     settings.setSupportMultipleWindows(true);
+    settings.setUseWideViewPort(false);
 
     // Additional settings for auth popup
     settings.setAllowFileAccess(true);


### PR DESCRIPTION
IITC replaces document.head.innerHTML during boot without a viewport meta tag. The NativeScript WebView plugin sets useWideViewPort=true by default, causing Android WebView to fall back to a 980px desktop viewport when the meta is absent. On rotation the scale (device_width/980) differs per orientation, producing a dramatic zoom effect.

Fix: set useWideViewPort=false to match native IITC Android app behavior, where device width is always used as the layout viewport regardless of viewport meta presence.

Also inject iitc-prime.css immediately after page load so styles are active before IITC rewrites document.head, then re-inject after iitcBootFinished once IITC has replaced the head.