### PR TITLE
feat: add immediateChange mode for live highlighter/layer switching

### DIFF
--- a/app/components/BottomPanel/ControlPanel/ControlListView.vue
+++ b/app/components/BottomPanel/ControlPanel/ControlListView.vue
@@ -68,6 +68,7 @@
           :items="item.fields[0].items"
           :selectedIndex="item.fields[0].items.indexOf(item.fields[0].selectedValue)"
           title="Select Highlighter"
+          immediateChange
           class="list-item--top-left list-item--bottom-left"
           @change="onHighlighterSelected"
         />
@@ -89,6 +90,7 @@
           idField="layerId"
           textField="name"
           title="Select Base Layer"
+          immediateChange
           class="list-item--top-right list-item--bottom-right"
           @change="onBaseLayerSelected"
         />

--- a/app/components/base/SelectField.vue
+++ b/app/components/base/SelectField.vue
@@ -36,6 +36,11 @@ export default {
     title: {
       type: String,
       default: 'Select an item'
+    },
+    // Emit change immediately on each tap without waiting for dialog confirmation
+    immediateChange: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -74,14 +79,27 @@ export default {
         // Convert items to string array for radio dialog
         const dialogItems = this.items.map(item => this.getItemText(item));
 
-        const result = await RadioDialog.show({
+        const options = {
           title: this.title,
           items: dialogItems,
           selectedIndex: this.currentSelectedIndex >= 0 ? this.currentSelectedIndex : undefined,
-          cancelButtonText: 'Cancel'
-        });
+          cancelButtonText: this.immediateChange ? 'OK' : 'Cancel'
+        };
 
-        if (!result.cancelled) {
+        if (this.immediateChange) {
+          options.onItemSelect = ({ selectedIndex }) => {
+            this.onSelectionChanged({
+              selectedIndex,
+              selectedId: this.getItemId(this.items[selectedIndex]),
+              item: this.items[selectedIndex]
+            });
+          };
+        }
+
+        const result = await RadioDialog.show(options);
+
+        // liveSelection: onItemSelect already handled each tap; Promise resolves cancelled on Android
+        if (!this.immediateChange && !result.cancelled) {
           this.onSelectionChanged({
             selectedIndex: result.selectedIndex,
             selectedId: this.getItemId(this.items[result.selectedIndex]),

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "nativescript-clipboard": "^2.1.1",
     "nativescript-compass": "^1.0.1",
     "nativescript-inappbrowser": "^3.2.0",
-    "nativescript-radio-dialog": "^1.0.4",
+    "nativescript-radio-dialog": "^1.1.0",
     "nativescript-vue": "^3.0.1",
     "nativescript-vue-devtools": "^1.5.1",
     "scored-fuzzysearch": "^1.0.5",


### PR DESCRIPTION
Use nativescript-radio-dialog onItemSelect callback to emit `@change` on every tap without waiting for dialog confirmation. Enabled for highlighter and base layer selectors in the control panel.