### PR TITLE
fix: stop iOS layer switch toggle cascade on layers panel

### DIFF
--- a/app/components/BottomPanel/ControlPanel/ControlListView.vue
+++ b/app/components/BottomPanel/ControlPanel/ControlListView.vue
@@ -103,10 +103,10 @@
           <SVGView
             v-if="index <= 8"
             class="overlay-portal"
-            :class="{ 'overlay-portal--active': portal.active === true }"
+            :class="{ 'overlay-portal--active': $store.state.map.overlayLayers[portal.index]?.active === true }"
             :col="index"
             @tap="onOverlayPortalToggle($event, portal.index)"
-            :src="'~/assets/icons/portals/portal_L' + index + '_' + String(portal.active) + '.svg'"
+            :src="'~/assets/icons/portals/portal_L' + index + '_' + String(!!$store.state.map.overlayLayers[portal.index]?.active) + '.svg'"
             stretch="aspectFit"
           />
         </template>
@@ -140,8 +140,8 @@
           <Label class="overlay-item-label" :text="switchItem.name" col="0" row="0" />
           <MDSwitch
             class="switch"
-            :checked="switchItem.active"
             @checkedChange="args => onOverlayToggle(switchItem.index, args.value)"
+            :checked="$store.state.map.overlayLayers[switchItem.index]?.active"
             col="1"
             row="0"
           />
@@ -160,8 +160,8 @@
         <Label class="overlay-item-label" :text="item.item.name" col="0" row="0" />
         <MDSwitch
           class="switch"
-          :checked="item.item.active"
           @checkedChange="args => onOverlayToggle(item.item.index, args.value)"
+          :checked="$store.state.map.overlayLayers[item.item.index]?.active"
           col="1"
           row="0"
         />
@@ -250,7 +250,8 @@ export default {
 
     onOverlayToggle(index, value) {
       if (typeof value === 'boolean') {
-        // Direct value from switch event
+        const currentLayer = this.$store.state.map.overlayLayers[index];
+        if (!currentLayer || currentLayer.active === value) return;
         this.$store.dispatch('map/setOverlayLayerProperty', { index, active: value });
       } else {
         // Label tap - toggle current state

--- a/app/components/BottomPanel/ControlPanel/services/controlPanelDataService.js
+++ b/app/components/BottomPanel/ControlPanel/services/controlPanelDataService.js
@@ -89,7 +89,7 @@ export class ControlPanelDataService {
         type: 'portal-icons-group',
         id: 'portal-icons',
         portals: overlayLayers.slice(0, 9).map((layer, index) => ({
-          ...layer,
+          layerId: layer.layerId,
           index,
         })),
       });
@@ -108,8 +108,12 @@ export class ControlPanelDataService {
   }
 
   static generateSwitchItems(overlayLayers) {
+    // Read only static props (layerId, name) - NOT active.
+    // active is read directly from the store in templates so that
+    // SET_OVERLAY_LAYER_PROPERTY does not invalidate currentListItems
+    // and trigger a full ListView rebind.
     const filteredLayers = overlayLayers
-      .map((layer, index) => ({ ...layer, index }))
+      .map((layer, index) => ({ layerId: layer.layerId, name: layer.name, index }))
       .filter(layer => layer.index > 8);
 
     const items = [];
@@ -127,7 +131,9 @@ export class ControlPanelDataService {
           type: 'switch-pair',
           id: `switch-pair-${pairIndex}`,
           items: pair.map((item, idx) => ({
-            ...item,
+            layerId: item.layerId,
+            name: item.name,
+            index: item.index,
             isTopLeft: pairIndex === 0 && idx === 0,
             isTopRight: pairIndex === 0 && idx === 1,
             isBottomLeft: pairIndex === totalPairs - 1 && idx === 0,
@@ -140,7 +146,7 @@ export class ControlPanelDataService {
         items.push({
           type: 'switch-single',
           id: `switch-single-${pair[0].index}`,
-          item: pair[0],
+          item: { layerId: pair[0].layerId, name: pair[0].name, index: pair[0].index },
         });
       }
     }
@@ -151,7 +157,7 @@ export class ControlPanelDataService {
       items.push({
         type: 'switch-single',
         id: `switch-single-${item.index}`,
-        item,
+        item: { layerId: item.layerId, name: item.name, index: item.index },
         isFirst: index === 0,
         isLast: index === singleItems.length - 1,
       });

--- a/app/store/modules/map.js
+++ b/app/store/modules/map.js
@@ -53,7 +53,20 @@ export const map = {
       state.baseLayersList = layers;
     },
     SET_OVERLAY_LAYERS(state, layers) {
-      state.overlayLayers = layers;
+      const existing = state.overlayLayers;
+      const sameStructure =
+        existing.length === layers.length &&
+        layers.every((l, i) => l.layerId === existing[i].layerId);
+      if (!sameStructure) {
+        state.overlayLayers = layers;
+        return;
+      }
+      // Same layer set - update only changed properties in-place so that
+      // computed properties depending on the array reference don't invalidate.
+      layers.forEach((layer, i) => {
+        if (existing[i].active !== layer.active) existing[i].active = layer.active;
+        if (existing[i].name !== layer.name) existing[i].name = layer.name;
+      });
     },
     SET_OVERLAY_LAYER_PROPERTY(state, { index, active }) {
       state.overlayLayers[index].active = active;


### PR DESCRIPTION
On iOS, MDSwitch fires checkedChange on every programmatic `:checked` update (not just user interaction), and ListView cell recycling accumulates stale handlers without removing old ones. Together, a single tap dispatched multiple toggle actions with stale indices, causing runaway on/off flipping.

Three-part fix:
- `SET_OVERLAY_LAYERS` does an in-place update when layer structure is unchanged, keeping the array reference stable so `currentListItems` is not recomputed and cells are not recreated (no handler accumulation)
- Switch items carry only static props (`layerId`, `name`, `index`); `:checked` reads `$store.state` directly per-cell so reactive updates bypass the list entirely
- `onOverlayToggle` guards against no-op dispatches when value already matches the current store state (blocks spurious events on initial cell bind)