### PR TITLE
fix: disable iOS UITableViewCell selection highlight in list views

### DIFF
--- a/app/components/BottomPanel/ControlPanel/ControlListView.vue
+++ b/app/components/BottomPanel/ControlPanel/ControlListView.vue
@@ -8,6 +8,7 @@
     :itemTemplateSelector="templateSelector"
     separatorColor="#00000000"
     iosEstimatedRowHeight="44"
+    @itemLoading="disableListItemHighlight"
   >
     <template #default="{ item }">
       <Label text="Unknown item type" />
@@ -103,10 +104,19 @@
           <SVGView
             v-if="index <= 8"
             class="overlay-portal"
-            :class="{ 'overlay-portal--active': $store.state.map.overlayLayers[portal.index]?.active === true }"
+            :class="{
+              'overlay-portal--active':
+                $store.state.map.overlayLayers[portal.index]?.active === true,
+            }"
             :col="index"
             @tap="onOverlayPortalToggle($event, portal.index)"
-            :src="'~/assets/icons/portals/portal_L' + index + '_' + String(!!$store.state.map.overlayLayers[portal.index]?.active) + '.svg'"
+            :src="
+              '~/assets/icons/portals/portal_L' +
+              index +
+              '_' +
+              String(!!$store.state.map.overlayLayers[portal.index]?.active) +
+              '.svg'
+            "
             stretch="aspectFit"
           />
         </template>
@@ -173,6 +183,7 @@
 <script>
 import SelectField from '@/components/base/SelectField.vue';
 import { $navigateTo } from 'nativescript-vue';
+import { disableListItemHighlight } from '@/utils/platform';
 import SettingsView from '@/components/Settings/SettingsView';
 import PluginsView from '@/components/Settings/PluginsView';
 
@@ -199,6 +210,8 @@ export default {
   },
 
   methods: {
+    disableListItemHighlight,
+
     // Template selector function - determines which template to use
     templateSelector(data) {
       const validTypes = [

--- a/app/components/Settings/LicensesView.vue
+++ b/app/components/Settings/LicensesView.vue
@@ -10,6 +10,7 @@
         class="licenses-list"
         separatorColor="transparent"
         @loaded="onLoaded"
+        @itemLoading="disableListItemHighlight"
         @itemTap="onItemTap"
       >
         <template #default="{ item }">
@@ -32,7 +33,7 @@
 import { markRaw } from 'vue';
 import SettingsBase from './SettingsBase';
 import { openUrl } from '@nativescript/core/utils';
-import { enableListEdgeToEdge } from '@/utils/platform';
+import { enableListEdgeToEdge, disableListItemHighlight } from '@/utils/platform';
 
 export default {
   name: 'LicensesView',
@@ -55,6 +56,8 @@ export default {
     onLoaded(args) {
       enableListEdgeToEdge(args.object);
     },
+
+    disableListItemHighlight,
 
     loadLicenses() {
       let licensesData = null;

--- a/app/utils/platform.js
+++ b/app/utils/platform.js
@@ -56,6 +56,18 @@ export const enableListEdgeToEdge = listView => {
 };
 
 /**
+ * Disable iOS UITableViewCell selection highlight on list items.
+ * On iOS, cells flash white on tap by default (UITableViewCellSelectionStyleDefault).
+ * Call from the `@itemLoading` event handler of the ListView.
+ * @param {object} args - NativeScript itemLoading event args
+ */
+export const disableListItemHighlight = args => {
+  if (isIOS && args.ios) {
+    args.ios.selectionStyle = 0; // UITableViewCellSelectionStyleNone
+  }
+};
+
+/**
  * Universal sharing function for different content types
  * @param {any} content - Content to share (object for geo, string for text/url)
  * @param {string} contentType - Type of content ('geo', 'text', 'url', 'prime')


### PR DESCRIPTION
On iOS, tapping any ListView row triggers a white flash animation (UITableViewCellSelectionStyleDefault). NativeScript has no declarative property for this, so `selectionStyle` is set to `None` via `itemLoading`