### PR TITLE
chore: migrate to lib-iitc-manager v2

### DIFF
--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -2,6 +2,7 @@
 
 import { Frame } from '@nativescript/core';
 import { Toasty } from '@triniwiz/nativescript-toasty';
+import { validateCustomChannelUrl } from 'lib-iitc-manager';
 import { managerService } from '@/utils/manager-service';
 
 let pendingWebViewReload = null;
@@ -208,7 +209,7 @@ export const manager = {
      * Validate custom channel URL
      */
     async checkCustomChannelUrl(_, url) {
-      return await managerService.validateCustomChannelUrl(url);
+      return await validateCustomChannelUrl(url);
     },
 
     /**

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -65,7 +65,7 @@ export const manager = {
         onPluginEvent: event => {
           dispatch('handlePluginEvent', event);
         },
-        onPluginsChanged: plugins => {
+        onPluginsViewChanged: plugins => {
           commit('SET_PLUGINS', plugins);
         },
       });

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -1,9 +1,19 @@
 // Copyright (C) 2025-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { Frame } from '@nativescript/core';
+import { Toasty } from '@triniwiz/nativescript-toasty';
 import { managerService } from '@/utils/manager-service';
 
 let pendingWebViewReload = null;
+
+const MESSAGES = {
+  serverNotAvailableRetry: args => `Server is not available. Retry after ${args} seconds`,
+};
+
+function showManagerMessage(message, args) {
+  const text = MESSAGES[message]?.(args) ?? message;
+  new Toasty({ text }).show();
+}
 
 export const manager = {
   namespaced: true,
@@ -54,7 +64,7 @@ export const manager = {
       // Set callbacks for handling Manager events
       managerService.setCallbacks({
         onMessage: (message, args) => {
-          dispatch('ui/showMessage', message, { root: true });
+          showManagerMessage(message, args);
         },
         onProgress: isShow => {
           commit('SET_PROGRESS', isShow);

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -65,6 +65,9 @@ export const manager = {
         onPluginEvent: event => {
           dispatch('handlePluginEvent', event);
         },
+        onPluginsChanged: plugins => {
+          commit('SET_PLUGINS', plugins);
+        },
       });
 
       commit('SET_PROGRESS', true);

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -78,7 +78,6 @@ export const manager = {
         commit('SET_RUNNING', data.isRunning);
         commit('SET_CURRENT_CHANNEL', data.currentChannel);
         commit('SET_CUSTOM_CHANNEL_URL', data.customChannelUrl);
-        commit('SET_PLUGINS', data.plugins);
         commit('SET_INITIALIZED', true);
 
         return data;
@@ -126,7 +125,6 @@ export const manager = {
       try {
         const data = await managerService.setUpdateChannel(channel);
         commit('SET_CURRENT_CHANNEL', data.currentChannel);
-        commit('SET_PLUGINS', data.plugins);
         return data;
       } catch (error) {
         // Revert on error
@@ -186,12 +184,7 @@ export const manager = {
       commit('UPDATE_PLUGIN_STATUS', { uid, status: action });
 
       try {
-        const data = await managerService.managePlugin(uid, action);
-
-        // Update full plugins list
-        commit('SET_PLUGINS', data.plugins);
-
-        return data;
+        await managerService.managePlugin(uid, action);
       } catch (error) {
         // Revert on error
         if (previousStatus) {
@@ -211,10 +204,8 @@ export const manager = {
     /**
      * Add user scripts (external plugins)
      */
-    async addUserScripts({ commit }, scripts) {
-      const data = await managerService.addUserScripts(scripts);
-      commit('SET_PLUGINS', data.plugins);
-      return data;
+    async addUserScripts(_, scripts) {
+      return await managerService.addUserScripts(scripts);
     },
 
     /**

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -97,18 +97,15 @@ export class ManagerService {
     const manager = await this.initialize();
     await manager.run();
 
-    // Load all initial data in parallel
-    const [channel, customUrl, plugins] = await Promise.all([
+    const [channel, customUrl] = await Promise.all([
       this.getUpdateChannel(),
       this.getCustomChannelUrl(),
-      this.getPlugins(),
     ]);
 
     return {
       isRunning: true,
       currentChannel: channel,
       customChannelUrl: customUrl,
-      plugins,
     };
   }
 
@@ -146,13 +143,7 @@ export class ManagerService {
   async setUpdateChannel(channel) {
     const manager = await this.initialize();
     await manager.setChannel(channel);
-
-    // Return updated data
-    const plugins = await this.getPlugins();
-    return {
-      currentChannel: channel,
-      plugins,
-    };
+    return { currentChannel: channel };
   }
 
   /**
@@ -250,13 +241,6 @@ export class ManagerService {
   async managePlugin(uid, action) {
     const manager = await this.initialize();
     await manager.managePlugin(uid, action);
-
-    // Return updated plugins
-    const plugins = await this.getPlugins();
-    return {
-      plugins,
-      updatedPlugin: { uid, status: action },
-    };
   }
 
   /**
@@ -264,14 +248,7 @@ export class ManagerService {
    */
   async addUserScripts(scripts) {
     const manager = await this.initialize();
-    const result = await manager.addUserScripts(scripts);
-
-    // Return updated plugins
-    const plugins = await this.getPlugins();
-    return {
-      result,
-      plugins,
-    };
+    return await manager.addUserScripts(scripts);
   }
 
   /**

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -182,41 +182,6 @@ export class ManagerService {
     };
   }
 
-  /**
-   * Validate custom channel URL
-   */
-  async validateCustomChannelUrl(url) {
-    if (!url) return false;
-
-    try {
-      // Ensure URL has http/https prefix
-      let fullUrl = url;
-      if (!/^https?:\/\//i.test(fullUrl)) {
-        fullUrl = 'http://' + fullUrl;
-      }
-
-      // Test if meta.json is accessible
-      const metaUrl = fullUrl.endsWith('/') ? `${fullUrl}meta.json` : `${fullUrl}/meta.json`;
-
-      const metaUrlWithCacheBust = `${metaUrl}?${Date.now()}`;
-
-      const response = await fetch(metaUrlWithCacheBust, {
-        method: 'GET',
-        timeout: 2000,
-        headers: {
-          Accept: '*/*',
-          Range: 'bytes=0-0', // Request only first byte
-        },
-      });
-
-      // Accept both 200 (full response) and 206 (partial content from Range request)
-      return response.status === 200 || response.status === 206;
-    } catch (error) {
-      console.error('[ManagerService] Error checking custom URL:', error);
-      return false;
-    }
-  }
-
   // === Plugin Management ===
 
   /**

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -16,7 +16,7 @@ export class ManagerService {
       onProgress: null,
       onInjectPlugin: null,
       onPluginEvent: null,
-      onPluginsChanged: null,
+      onPluginsViewChanged: null,
     };
   }
 
@@ -38,8 +38,8 @@ export class ManagerService {
             await storage.set(obj);
           },
         },
-        gm_api: {
-          bridge_adapter_code: `
+        gmApi: {
+          bridgeAdapterCode: `
             window.__iitc_gm_bridge__ = {
               send(data) {
                 window.nsWebViewBridge.emit('gmBridgeRequest', JSON.stringify(data));
@@ -56,28 +56,28 @@ export class ManagerService {
             this.callbacks.onMessage(message, args);
           }
         },
-        progressbar: isShow => {
+        onProgress: isShow => {
           if (this.callbacks.onProgress) {
             this.callbacks.onProgress(isShow);
           }
         },
-        inject_plugin: plugin => {
+        injectPlugin: plugin => {
           if (this.callbacks.onInjectPlugin) {
             this.callbacks.onInjectPlugin(plugin);
           }
         },
-        plugin_event: event => {
+        onPluginEvent: event => {
           if (this.callbacks.onPluginEvent) {
             this.callbacks.onPluginEvent(event);
           }
         },
-        plugins_changed: plugins => {
-          if (this.callbacks.onPluginsChanged) {
-            this.callbacks.onPluginsChanged(plugins);
+        onPluginsViewChanged: view => {
+          if (this.callbacks.onPluginsViewChanged) {
+            this.callbacks.onPluginsViewChanged(view.plugins);
           }
         },
-        use_fetch_head_method: false,
-        is_daemon: false,
+        useFetchHeadMethod: false,
+        isDaemon: false,
       });
 
       this.isInitialized = true;
@@ -299,7 +299,7 @@ export class ManagerService {
       onProgress: null,
       onInjectPlugin: null,
       onPluginEvent: null,
-      onPluginsChanged: null,
+      onPluginsViewChanged: null,
     };
   }
 }

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -160,13 +160,7 @@ export class ManagerService {
    */
   async getUpdateInterval(channel) {
     const manager = await this.initialize();
-    if (!channel) {
-      channel = manager.channel;
-    }
-
-    const key = `${channel}_update_check_interval`;
-    const data = await manager.storage.get([key]);
-    return data[key] || 86400;
+    return await manager.getUpdateCheckInterval(channel);
   }
 
   /**

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -16,6 +16,7 @@ export class ManagerService {
       onProgress: null,
       onInjectPlugin: null,
       onPluginEvent: null,
+      onPluginsChanged: null,
     };
   }
 
@@ -68,6 +69,11 @@ export class ManagerService {
         plugin_event: event => {
           if (this.callbacks.onPluginEvent) {
             this.callbacks.onPluginEvent(event);
+          }
+        },
+        plugins_changed: plugins => {
+          if (this.callbacks.onPluginsChanged) {
+            this.callbacks.onPluginsChanged(plugins);
           }
         },
         use_fetch_head_method: false,
@@ -234,12 +240,7 @@ export class ManagerService {
    */
   async getPlugins() {
     const manager = await this.initialize();
-    const channel = manager.channel;
-    const storage = manager.storage;
-
-    const key = `${channel}_plugins_flat`;
-    const data = await storage.get([key]);
-    return data[key] || {};
+    return (await manager.getPluginsView()).plugins;
   }
 
   /**
@@ -298,6 +299,7 @@ export class ManagerService {
       onProgress: null,
       onInjectPlugin: null,
       onPluginEvent: null,
+      onPluginsChanged: null,
     };
   }
 }

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -177,8 +177,7 @@ export class ManagerService {
    */
   async getCustomChannelUrl() {
     const manager = await this.initialize();
-    const data = await manager.storage.get(['network_host']);
-    return data.network_host && data.network_host.custom ? data.network_host.custom : '';
+    return manager.networkHost?.custom ?? '';
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@nativescript/theme": "^3.1.0",
     "@nstudio/nativescript-checkbox": "^2.0.5",
     "@triniwiz/nativescript-toasty": "^4.1.3",
-    "lib-iitc-manager": "^1.13.4",
+    "lib-iitc-manager": "^2.0.0",
     "nativescript-clipboard": "^2.1.1",
     "nativescript-compass": "^1.0.1",
     "nativescript-inappbrowser": "^3.2.0",


### PR DESCRIPTION
- Bump `lib-iitc-manager` to v2.0.0
- Adopt camelCase Manager config API
- Use `manager.networkHost`, `manager.getUpdateCheckInterval()`, `getPluginsView()` instead of direct storage access
- Replace local `validateCustomChannelUrl` with the library implementation
- Remove redundant `getPlugins()` calls after mutations
- Fix manager messages shown as toast notifications