### PR TITLE
feat(ios): add NSLocationWhenInUseUsageDescription for App Store

### DIFF
--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -20,6 +20,8 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>175353347</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>IITC Prime can show your current position on the Ingress intel map. Location access is optional.</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UILaunchStoryboardName</key>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:android:gplay-release": "BUILD_TYPE=release ns build android --release --clean --aab --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.snapshot --env.compileSnapshot --env.uglify --env.sentry",
     "run:ios": "ns run ios",
     "build:ios:release": "BUILD_TYPE=release ns build ios --release --env.uglify --env.sentry",
-    "build:ios:beta": "BUILD_TYPE=beta ns build ios --env.sentry",
+    "build:ios:beta": "BUILD_TYPE=beta APP_ID_SUFFIX= ns build ios --env.sentry",
     "clean": "ns clean",
     "lint": "ns build android --no-copy && echo 'Syntax check passed'",
     "format": "prettier --write .",


### PR DESCRIPTION
Apple requires a usage description string whenever an app may request location access, even if it is optional