### PR TITLE
feat: add zoom controls setting

### DIFF
--- a/app/components/Settings/SettingsView.vue
+++ b/app/components/Settings/SettingsView.vue
@@ -53,6 +53,14 @@
 
     <SettingsItem
       type="switch"
+      title="Show zoom controls"
+      description="Show +/- buttons on the map"
+      :value="zoomControl"
+      @change="updateZoomControl"
+    />
+
+    <SettingsItem
+      type="switch"
       title="Fake User Agent"
       description="Appear as a desktop browser"
       :value="fakeUserAgent"
@@ -126,6 +134,7 @@ export default {
   computed: {
     ...mapGetters('settings', [
       'isDesktopMode',
+      'isZoomControl',
       'isFakeUserAgent',
       'isPersistentZoom',
       'isShowLocation',
@@ -134,6 +143,10 @@ export default {
 
     desktopMode() {
       return this.isDesktopMode;
+    },
+
+    zoomControl() {
+      return this.isZoomControl;
     },
 
     fakeUserAgent() {
@@ -164,6 +177,10 @@ export default {
 
     async updateDesktopMode(value) {
       await this.setSetting({ key: 'desktopMode', value });
+    },
+
+    async updateZoomControl(value) {
+      await this.setSetting({ key: 'zoomControl', value });
     },
 
     async updateFakeUserAgent(value) {

--- a/app/store/modules/settings.js
+++ b/app/store/modules/settings.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+// Copyright (C) 2025-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import storage from '@/utils/storage';
 
@@ -8,6 +8,7 @@ export const settings = {
   state: () => ({
     // UI settings
     desktopMode: false,
+    zoomControl: false,
     fakeUserAgent: false,
 
     // Location settings
@@ -27,7 +28,7 @@ export const settings = {
           state[key] = settings[key];
         }
       });
-    }
+    },
   },
 
   actions: {
@@ -76,6 +77,10 @@ export const settings = {
       if (changedKeys.length === 0 || changedKeys.includes('showLocation')) {
         await dispatch('map/setLocationTracking', state.showLocation, { root: true });
       }
+      // Zoom control changed - reload WebView
+      if (changedKeys.includes('zoomControl')) {
+        await dispatch('ui/reloadWebView', null, { root: true });
+      }
     },
 
     /**
@@ -84,6 +89,7 @@ export const settings = {
     async resetSettings({ commit, dispatch }) {
       const defaultSettings = {
         desktopMode: false,
+        zoomControl: false,
         fakeUserAgent: false,
         persistentZoom: false,
         showLocation: false,
@@ -105,14 +111,15 @@ export const settings = {
       } catch (error) {
         console.error('Failed to update showLocation setting from plugin:', error);
       }
-    }
+    },
   },
 
   getters: {
     // Quick access getters
     isDesktopMode: state => state.desktopMode,
+    isZoomControl: state => state.zoomControl,
     isFakeUserAgent: state => state.fakeUserAgent,
     isPersistentZoom: state => state.persistentZoom,
     isShowLocation: state => state.showLocation,
-  }
+  },
 };

--- a/app/utils/bridge.js
+++ b/app/utils/bridge.js
@@ -5,6 +5,7 @@ import {
   switchToPane,
   bootFinished,
   getVersionName,
+  getZoomControl,
   setLayers,
   addPane,
   setPortalStatus,
@@ -162,6 +163,8 @@ export const injectBridgeIITC = async webview => {
   });
   bridge +=
     "window.nsWebViewBridge.getVersionName = function() {return '" + getVersionName() + "'};\n";
+  bridge +=
+    'window.nsWebViewBridge.showZoom = function() {return ' + getZoomControl() + ';};\n';
 
   // async callback-based bridge functions
   Object.entries(asyncEvents).forEach(entry => {

--- a/app/utils/events-from-iitc.js
+++ b/app/utils/events-from-iitc.js
@@ -33,6 +33,14 @@ export const getVersionName = () => {
 };
 
 /**
+ * Returns whether zoom control buttons should be shown
+ * @returns {boolean}
+ */
+export const getZoomControl = () => {
+  return store.getters['settings/isZoomControl'];
+};
+
+/**
  * Fires when IITC completes its initialization process
  */
 export const bootFinished = async name => {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@nativescript/theme": "^3.1.0",
     "@nstudio/nativescript-checkbox": "^2.0.5",
     "@triniwiz/nativescript-toasty": "^4.1.3",
-    "lib-iitc-manager": "^2.0.0",
+    "lib-iitc-manager": "^2.0.1",
     "nativescript-clipboard": "^2.1.1",
     "nativescript-compass": "^1.0.1",
     "nativescript-inappbrowser": "^3.2.0",


### PR DESCRIPTION
Add a "Show zoom controls" toggle in Settings.
Implements window.app.showZoom() in the WebView bridge so IITC can read the setting before Leaflet initialises and set window.mapOptions.zoomControl accordingly.