### PR TITLE
fix(ios): bottom sheet snap, keyboard navigation crash, CFBundleName

### DIFF
--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -67,6 +67,8 @@
     </array>
     <key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>CFBundleURLTypes</key>
     <array>
       <dict>

--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>${PRODUCT_NAME}</string>
+    <string>IITC Prime</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/app/components/Settings/components/CustomActionBar.vue
+++ b/app/components/Settings/components/CustomActionBar.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-import { Frame, Screen } from '@nativescript/core';
+import { Frame, Screen, Utils } from '@nativescript/core';
 
 const ANIMATION_DURATION = 300;
 
@@ -101,6 +101,7 @@ export default {
 
   methods: {
     goBack() {
+      Utils.dismissSoftInput();
       Frame.topmost().goBack();
     },
 
@@ -134,7 +135,7 @@ export default {
       if (hide) this.slotOriginalWidth = currentWidth;
 
       const fromWidth = currentWidth;
-      const toWidth = hide ? 0 : (this.slotOriginalWidth || 0);
+      const toWidth = hide ? 0 : this.slotOriginalWidth || 0;
       const fromOpacity = hide ? 1 : 0;
       const toOpacity = hide ? 0 : 1;
       const startTime = Date.now();
@@ -160,13 +161,21 @@ export default {
 @import '@/app';
 
 @keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fade-out {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 .action-bar-wrapper {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "lib-iitc-manager": "^2.0.1",
     "nativescript-clipboard": "^2.1.1",
     "nativescript-compass": "^1.0.1",
-    "nativescript-inappbrowser": "^3.2.0",
     "nativescript-radio-dialog": "^1.1.0",
     "nativescript-vue": "^3.0.1",
     "nativescript-vue-devtools": "^1.5.1",

--- a/patches/@nativescript-community+ui-persistent-bottomsheet+0.1.10.patch
+++ b/patches/@nativescript-community+ui-persistent-bottomsheet+0.1.10.patch
@@ -1,0 +1,47 @@
+diff --git a/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js b/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js
+index ddb35cd..c6d6a30 100644
+--- a/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js
++++ b/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js
+@@ -404,15 +404,23 @@ let PersistentBottomSheet = class PersistentBottomSheet extends AbsoluteLayout {
+         }
+         else if (event.action === 'up' || event.action === 'cancel') {
+             this.vt?.addMovement(p.getX(), p.getY());
+-            // If we were dragging the panel, animate to nearest step
+-            // BUT: ignore 'cancel' events from tap handlers (they shouldn't trigger animation)
+-            if (this.wasDraggingPanel && event.action === 'up') {
+-                this.vt?.computeCurrentVelocity(1000);
+-                const velocityY = -(this.vt?.getYVelocity() ?? 0);
+-                this.vt?.recycle();
+-                const y = touchY - (this.lastTouchY || touchY);
+-                const totalDelta = this.translationY + y + this.dragToss * velocityY;
+-                this.computeAndAnimateEndGestureAnimation(-totalDelta);
++            // If we were dragging the panel, animate to nearest step.
++            // On iOS a button tap during swipe fires 'cancel' on the scrollView - we must snap
++            // to the nearest step position in that case too.
++            if (this.wasDraggingPanel) {
++                if (event.action === 'up') {
++                    this.vt?.computeCurrentVelocity(1000);
++                    const velocityY = -(this.vt?.getYVelocity() ?? 0);
++                    this.vt?.recycle();
++                    const y = touchY - (this.lastTouchY || touchY);
++                    const totalDelta = this.translationY + y + this.dragToss * velocityY;
++                    this.computeAndAnimateEndGestureAnimation(-totalDelta);
++                } else {
++                    // cancel during drag (e.g. iOS button tap interrupts swipe) — snap to
++                    // nearest step based on current position, no velocity
++                    this.vt?.recycle();
++                    this.computeAndAnimateEndGestureAnimation(-this.translationY);
++                }
+                 this.wasDraggingPanel = false;
+             }
+             // only reset on bottomsheet up/cancel event (will happen after scrollView up/cancel)
+@@ -592,6 +600,9 @@ let PersistentBottomSheet = class PersistentBottomSheet extends AbsoluteLayout {
+     async animateToPosition(position, duration = OPEN_DURATION, curve = CoreTypes.AnimationCurve.easeOut) {
+         if (this.animation) {
+             this.animation.cancel();
++            // Reset synchronously so the guard below does not block the new animation.
++            // The previous call's finally block will run later but animating is already false.
++            this.animating = false;
+         }
+         if (this.animating) {
+             return;


### PR DESCRIPTION
- Fix bottom sheet panel getting stuck when a button is tapped during a swipe on iOS
- Fix `TypeError: Cannot read properties of undefined (reading 'resolvedPage')` crash when navigating back from a Settings screen while the keyboard is visible
- Fix `CFBundleName`
- Remove unused `nativescript-inappbrowser` dependency