### PR TITLE
fix(bottomsheet): restrict cancel-snap to iOS only

### DIFF
--- a/patches/@nativescript-community+ui-persistent-bottomsheet+0.1.10.patch
+++ b/patches/@nativescript-community+ui-persistent-bottomsheet+0.1.10.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js b/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js
-index ddb35cd..c6d6a30 100644
+index ddb35cd..96593c0 100644
 --- a/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js
 +++ b/node_modules/@nativescript-community/ui-persistent-bottomsheet/index.js
-@@ -404,15 +404,23 @@ let PersistentBottomSheet = class PersistentBottomSheet extends AbsoluteLayout {
+@@ -404,15 +404,25 @@ let PersistentBottomSheet = class PersistentBottomSheet extends AbsoluteLayout {
          }
          else if (event.action === 'up' || event.action === 'cancel') {
              this.vt?.addMovement(p.getX(), p.getY());
@@ -16,8 +16,7 @@ index ddb35cd..c6d6a30 100644
 -                const totalDelta = this.translationY + y + this.dragToss * velocityY;
 -                this.computeAndAnimateEndGestureAnimation(-totalDelta);
 +            // If we were dragging the panel, animate to nearest step.
-+            // On iOS a button tap during swipe fires 'cancel' on the scrollView - we must snap
-+            // to the nearest step position in that case too.
++            // On iOS a button tap during a swipe fires 'cancel' - the panel must snap in that case too
 +            if (this.wasDraggingPanel) {
 +                if (event.action === 'up') {
 +                    this.vt?.computeCurrentVelocity(1000);
@@ -27,15 +26,18 @@ index ddb35cd..c6d6a30 100644
 +                    const totalDelta = this.translationY + y + this.dragToss * velocityY;
 +                    this.computeAndAnimateEndGestureAnimation(-totalDelta);
 +                } else {
-+                    // cancel during drag (e.g. iOS button tap interrupts swipe) — snap to
-+                    // nearest step based on current position, no velocity
++                    // Always recycle the velocity tracker. Only snap on iOS: on Android
++                    // ACTION_CANCEL means a parent view intercepted the gesture and will
++                    // deliver its own ACTION_UP, so the panel position resolves naturally.
 +                    this.vt?.recycle();
-+                    this.computeAndAnimateEndGestureAnimation(-this.translationY);
++                    if (global.isIOS) {
++                        this.computeAndAnimateEndGestureAnimation(-this.translationY);
++                    }
 +                }
                  this.wasDraggingPanel = false;
              }
              // only reset on bottomsheet up/cancel event (will happen after scrollView up/cancel)
-@@ -592,6 +600,9 @@ let PersistentBottomSheet = class PersistentBottomSheet extends AbsoluteLayout {
+@@ -592,6 +602,9 @@ let PersistentBottomSheet = class PersistentBottomSheet extends AbsoluteLayout {
      async animateToPosition(position, duration = OPEN_DURATION, curve = CoreTypes.AnimationCurve.easeOut) {
          if (this.animation) {
              this.animation.cancel();


### PR DESCRIPTION
On Android, ACTION_CANCEL means a parent view intercepted the gesture and will deliver its own ACTION_UP - snapping is not needed.
The previous patch applied the snap on both platforms, which caused a crash on Android (ViewGroup.TouchTarget double-recycle).