### PR TITLE
feat(plugins): show IITC core in plugin list, fix header clipping and override deletion UX

### DIFF
--- a/app/components/Settings/PluginsView.vue
+++ b/app/components/Settings/PluginsView.vue
@@ -55,6 +55,7 @@ import { mapActions, mapGetters } from 'vuex';
 import { reactive, markRaw } from 'vue';
 import { fuzzysearch } from 'scored-fuzzysearch';
 import { Toasty } from '@triniwiz/nativescript-toasty';
+import { confirm } from '@/utils/dialogs';
 import { downloadPlugin, parsePlugin, installPlugin } from '@/utils/plugin-installer';
 import { readFileContent } from '@/utils/file-manager';
 import SettingsBase from './SettingsBase';
@@ -346,10 +347,13 @@ export default {
     },
 
     async deletePlugin(plugin) {
+      const isOverride = !!plugin.override;
       const confirmed = await confirm({
-        title: 'Delete plugin',
-        message: `Are you sure you want to delete "${plugin.name}"?`,
-        okButtonText: 'Delete',
+        title: isOverride ? 'Remove override' : 'Delete plugin',
+        message: isOverride
+          ? `Remove the user override for "${plugin.name}"? The official version will be used instead.`
+          : `Are you sure you want to delete "${plugin.name}"?`,
+        okButtonText: isOverride ? 'Remove' : 'Delete',
         cancelButtonText: 'Cancel',
       });
 

--- a/app/components/Settings/PluginsView.vue
+++ b/app/components/Settings/PluginsView.vue
@@ -28,8 +28,9 @@
         <!-- Plugins container -->
         <GridLayout row="2" class="plugins-container" v-if="isPluginsVisible">
           <PluginsList
-            v-if="filteredPlugins.length > 0"
+            v-if="filteredPlugins.length > 0 || iitcCore"
             :plugins="filteredPlugins"
+            :iitcCore="iitcCore"
             :showEnabledFirst="activeCategory === 'All'"
             :bottomPadding="bottomPadding"
             @info="showPluginInfo"
@@ -37,7 +38,7 @@
             @delete="deletePlugin"
           />
           <Label
-            v-if="filteredPlugins.length === 0"
+            v-if="filteredPlugins.length === 0 && !iitcCore"
             :text="getEmptyMessage()"
             class="no-plugins"
             once="true"
@@ -87,10 +88,15 @@ export default {
   },
 
   computed: {
-    ...mapGetters('manager', ['plugins', 'lastPluginUpdate']),
+    ...mapGetters('manager', ['plugins', 'core', 'lastPluginUpdate']),
 
     allPlugins() {
       return this.plugins;
+    },
+
+    iitcCore() {
+      if (this.activeCategory !== 'All' || this.searchQuery.trim()) return null;
+      return this.core || null;
     },
 
     // Check if data is available

--- a/app/components/Settings/components/PluginInfoSheet.vue
+++ b/app/components/Settings/components/PluginInfoSheet.vue
@@ -12,15 +12,15 @@
     <ScrollView id="mainScrollView">
       <FlexboxLayout class="sheet-content">
         <!-- Header: icon + name / category -->
-        <FlexboxLayout class="plugin-header">
-          <AsyncSVGIcon v-if="isIconSVG" :src="pluginIcon" icon-class="plugin-icon" />
-          <AsyncRasterIcon v-else :src="pluginIcon" icon-class="plugin-icon" />
+        <GridLayout class="plugin-header" columns="64, *" rows="auto">
+          <AsyncSVGIcon v-if="isIconSVG" col="0" :src="pluginIcon" icon-class="plugin-icon" />
+          <AsyncRasterIcon v-else col="0" :src="pluginIcon" icon-class="plugin-icon" />
 
-          <StackLayout class="header-info">
+          <StackLayout col="1" class="header-info">
             <Label :text="displayName" class="plugin-name" textWrap="true" />
             <Label v-if="!isLoading" :text="plugin.category || 'Misc'" class="plugin-category" />
           </StackLayout>
-        </FlexboxLayout>
+        </GridLayout>
 
         <!-- Loading indicator -->
         <ActivityIndicator v-if="isLoading" busy="true" class="sheet-loading" />
@@ -243,16 +243,14 @@ export default {
 }
 
 .plugin-header {
-  flex-direction: row;
-  align-items: center;
   margin-bottom: $spacing-m;
 }
 
 .plugin-icon {
   width: 48;
   height: 48;
-  margin-right: $spacing-m;
-  flex-shrink: 0;
+  horizontal-alignment: left;
+  vertical-alignment: center;
 }
 
 .header-info {

--- a/app/components/Settings/components/PluginInfoSheet.vue
+++ b/app/components/Settings/components/PluginInfoSheet.vue
@@ -112,7 +112,12 @@
           class="btn-primary btn-action"
           @tap="onShareUpdate"
         />
-        <MDButton v-if="plugin.user" text="Delete plugin" class="btn-delete" @tap="onDelete" />
+        <MDButton
+          v-if="plugin.user || plugin.override"
+          :text="plugin.override ? 'Remove override' : 'Delete plugin'"
+          class="btn-delete"
+          @tap="onDelete"
+        />
       </FlexboxLayout>
     </ScrollView>
   </StackLayout>

--- a/app/components/Settings/components/plugins/PluginsList.vue
+++ b/app/components/Settings/components/plugins/PluginsList.vue
@@ -51,6 +51,7 @@
             <MDSwitch
               class="switch"
               :checked="item.status === 'on'"
+              :isEnabled="!item.isCore"
               isUserInteractionEnabled="false"
             />
           </GridLayout>
@@ -102,6 +103,7 @@
             <MDSwitch
               class="switch"
               :checked="item.status === 'on'"
+              :isEnabled="!item.isCore"
               isUserInteractionEnabled="false"
             />
           </GridLayout>
@@ -145,6 +147,11 @@ export default {
       type: Boolean,
       default: false,
     },
+    // IITC core script object (shown first in Enabled section when in All category)
+    iitcCore: {
+      type: Object,
+      default: null,
+    },
     // Optional section title
     title: {
       type: String,
@@ -167,18 +174,32 @@ export default {
           .filter(p => p.status === 'on')
           .sort((a, b) => this.getPluginName(a).localeCompare(this.getPluginName(b)));
 
-        // Add enabled plugins section if there are any enabled plugins
-        if (enabledPlugins.length > 0) {
+        // Enabled section always visible when core is present or there are enabled plugins
+        if (this.iitcCore || enabledPlugins.length > 0) {
           items.push({
             type: 'section-header',
             title: 'Enabled',
           });
+
+          // Core is always first in the Enabled section
+          if (this.iitcCore) {
+            items.push({
+              ...this.iitcCore,
+              type: 'plugin',
+              sectionId: 'enabled',
+              isCore: true,
+              status: 'on',
+              isFirst: true,
+              isLast: enabledPlugins.length === 0,
+            });
+          }
+
           items.push(
             ...enabledPlugins.map((plugin, index) => ({
               ...plugin,
               type: 'plugin',
               sectionId: 'enabled',
-              isFirst: index === 0,
+              isFirst: !this.iitcCore && index === 0,
               isLast: index === enabledPlugins.length - 1,
             }))
           );
@@ -288,6 +309,8 @@ export default {
     },
 
     async onSwitchTap(item) {
+      if (item.isCore) return;
+
       if (!this.showEnabledFirst) {
         this.$emit('toggle', item);
         return;

--- a/app/components/Settings/components/plugins/PluginsList.vue
+++ b/app/components/Settings/components/plugins/PluginsList.vue
@@ -59,9 +59,11 @@
         <Label
           ~rightDrawer
           :class="
-            item.user ? 'swipe-drawer swipe-drawer--delete' : 'swipe-drawer swipe-drawer--disable'
+            item.user || item.override
+              ? 'swipe-drawer swipe-drawer--delete'
+              : 'swipe-drawer swipe-drawer--disable'
           "
-          :text="$filters.fonticon(item.user ? 'fa-trash-alt' : 'fa-ban')"
+          :text="$filters.fonticon(item.user || item.override ? 'fa-trash-alt' : 'fa-ban')"
           class="fa"
           @tap="onSwipeAction(item)"
         />
@@ -111,9 +113,11 @@
         <Label
           ~rightDrawer
           :class="
-            item.user ? 'swipe-drawer swipe-drawer--delete' : 'swipe-drawer swipe-drawer--disable'
+            item.user || item.override
+              ? 'swipe-drawer swipe-drawer--delete'
+              : 'swipe-drawer swipe-drawer--disable'
           "
-          :text="$filters.fonticon(item.user ? 'fa-trash-alt' : 'fa-ban')"
+          :text="$filters.fonticon(item.user || item.override ? 'fa-trash-alt' : 'fa-ban')"
           class="fa"
           @tap="onSwipeAction(item)"
         />
@@ -231,6 +235,12 @@ export default {
     },
   },
 
+  watch: {
+    combinedItems() {
+      this.collectionViewRef?.closeCurrentMenu();
+    },
+  },
+
   methods: {
     // Template selector function - determines which template to use
     templateSelector(item, index, items) {
@@ -289,7 +299,7 @@ export default {
     },
 
     onSwipeAction(item) {
-      if (item.user) {
+      if (item.user || item.override) {
         this.$emit('delete', item);
       } else {
         this.collectionViewRef?.closeCurrentMenu();

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -24,6 +24,7 @@ export const manager = {
     isRunning: false,
     inProgress: false,
     plugins: {},
+    core: null,
     lastPluginUpdate: null,
     currentChannel: 'release',
     customChannelUrl: '',
@@ -42,6 +43,9 @@ export const manager = {
     SET_PLUGINS(state, plugins) {
       state.plugins = plugins;
       state.lastPluginUpdate = Date.now();
+    },
+    SET_CORE(state, core) {
+      state.core = core;
     },
     UPDATE_PLUGIN_STATUS(state, { uid, status }) {
       if (state.plugins[uid]) {
@@ -76,8 +80,9 @@ export const manager = {
         onPluginEvent: event => {
           dispatch('handlePluginEvent', event);
         },
-        onPluginsViewChanged: plugins => {
+        onPluginsViewChanged: (plugins, core) => {
           commit('SET_PLUGINS', plugins);
+          commit('SET_CORE', core);
         },
       });
 
@@ -181,8 +186,9 @@ export const manager = {
      * Load plugins into state
      */
     async loadPlugins({ commit }) {
-      const plugins = await managerService.getPlugins();
+      const { plugins, core } = await managerService.getPlugins();
       commit('SET_PLUGINS', plugins);
+      commit('SET_CORE', core);
       return plugins;
     },
 
@@ -277,6 +283,11 @@ export const manager = {
      * Get all plugins from Vuex state
      */
     plugins: state => state.plugins,
+
+    /**
+     * Get IITC core script
+     */
+    core: state => state.core,
 
     /**
      * Timestamp of last plugins update

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -73,7 +73,7 @@ export class ManagerService {
         },
         onPluginsViewChanged: view => {
           if (this.callbacks.onPluginsViewChanged) {
-            this.callbacks.onPluginsViewChanged(view.plugins);
+            this.callbacks.onPluginsViewChanged(view.plugins, view.core || null);
           }
         },
         useFetchHeadMethod: false,
@@ -189,7 +189,8 @@ export class ManagerService {
    */
   async getPlugins() {
     const manager = await this.initialize();
-    return (await manager.getPluginsView()).plugins;
+    const view = await manager.getPluginsView();
+    return { plugins: view.plugins, core: view.core || null };
   }
 
   /**


### PR DESCRIPTION
- IITC core script is now always shown as the first item in the **Enabled** section of the plugins list (visible only in the **All** category, hidden during search)
- Plugin info sheet header no longer clips long plugin names
- Delete confirmation dialog and button label now say **"Remove override"** instead of "Delete plugin" for any plugin with an override flag