### PR TITLE
Pre-register IITC scripts as document-start user scripts (iOS + Android)

### DIFF
--- a/App_Resources/Android/app.gradle
+++ b/App_Resources/Android/app.gradle
@@ -37,7 +37,7 @@ android {
   def buildingBundle = gradle.startParameter.taskNames.any { it.toLowerCase().contains('bundle') }
 
   defaultConfig {
-    minSdkVersion 23
+    minSdkVersion 24
     compileSdkVersion 36
     targetSdkVersion 36
     versionCode = getVersionCodeTimeStamps()

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import { injectBridgeIITC, router } from '@/utils/bridge';
+import { injectBridgeIITC, writeBridgeScriptFile, router } from '@/utils/bridge';
 import { injectCustomStyles, installFileChooserOverride } from '~/utils/iitc-prime-resources';
 import { injectDebugBridge } from '@/utils/debug-bridge';
 import BaseWebView from './BaseWebView.vue';
@@ -34,6 +34,9 @@ import {
   userLocationOrientation,
   setSafeAreaInsets,
 } from '@/utils/events-to-iitc';
+
+// Resource name for the pre-registered bridge script
+const BRIDGE_SCRIPT_NAME = 'iitcBridge';
 
 export default {
   name: 'AppWebView',
@@ -144,8 +147,13 @@ export default {
       this.injectionInProgress = true;
 
       try {
-        // Inject bridges first
-        await injectBridgeIITC(this.webview);
+        // The bridge is normally provided by the pre-registered atDocumentEnd
+        // script. Inject it here only if it is not available yet - the case on
+        // Android, where the auto-injected script loads asynchronously after load.
+        const hasBridge = await this.webview.executeJavaScript('typeof window.app !== "undefined"');
+        if (hasBridge !== true) {
+          await injectBridgeIITC(this.webview);
+        }
         await injectDebugBridge(this.webview);
 
         // Inject early so styles are active before IITC rewrites document.head
@@ -172,7 +180,23 @@ export default {
           nativeView.scrollView.contentInsetAdjustmentBehavior = 2;
         }
       }
+
+      // Register the bridge as an atDocumentEnd script so it is available before
+      // the page finishes loading (iOS), instead of injecting it after load.
+      await this.registerBridgeScript(webview);
+
       this.$emit('webview-loaded', { webview });
+    },
+
+    async registerBridgeScript(webview) {
+      if (!webview) return;
+      try {
+        const filePath = await writeBridgeScriptFile();
+        webview.removeAutoLoadJavaScriptFile(BRIDGE_SCRIPT_NAME);
+        await webview.autoLoadJavaScriptFile(BRIDGE_SCRIPT_NAME, filePath);
+      } catch (error) {
+        console.error('[AppWebView] Failed to register bridge script:', error);
+      }
     },
 
     handleBridgeMessage(eventData) {
@@ -214,6 +238,9 @@ export default {
               this.pendingReloadUrl = addViewportParam(action.payload);
               webview.loadUrl('about:blank');
             } else {
+              // Re-register so settings changes are reflected
+              // in the bridge on the next load.
+              await this.registerBridgeScript(webview);
               await this.$refs.baseWebView.reload();
             }
             break;

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -36,7 +36,7 @@ import {
 } from '@/utils/plugin-scripts';
 import BaseWebView from './BaseWebView.vue';
 import { addViewportParam, INGRESS_INTEL_MAP } from '@/utils/url-config';
-import { isIOS, Utils } from '@nativescript/core';
+import { isIOS, isAndroid, Utils } from '@nativescript/core';
 
 import {
   changePortalHighlights,
@@ -49,9 +49,9 @@ import {
   setSafeAreaInsets,
 } from '@/utils/events-to-iitc';
 
-// Scripts run as atDocumentEnd user scripts (iOS) before the page finishes loading.
-// On Android they load asynchronously, so `check` decides whether the fallback
-// `inject` is needed at load finish.
+// Scripts pre-registered to run at DOMContentLoaded on every navigation (iOS: WKUserScript
+// atDocumentEnd; Android: addDocumentStartJavaScript wrapped in a DOMContentLoaded guard).
+// The `check` expression detects cold-start absence so the fallback `inject` can run.
 const PRELOAD_SCRIPTS = [
   {
     name: 'iitcBridge',
@@ -137,8 +137,6 @@ export default {
         return;
       }
 
-      console.log('[AppWebView] onLoadStarted:', arg.url);
-
       try {
         if (arg.url.startsWith(INGRESS_INTEL_MAP)) {
           // Mark this URL as pending injection; onLoadFinished will inject only for this URL
@@ -193,7 +191,7 @@ export default {
         }
 
         // Flag is set by the trailing marker user script after all plugins ran.
-        // Not set on iOS cold start (manager not ready yet) and never on Android.
+        // Not set on cold start (manager not ready yet before first load).
         const pluginsReady = await this.webview.executeJavaScript(
           `window.${PLUGINS_READY_FLAG} === true`
         );
@@ -246,11 +244,25 @@ export default {
       }
     },
 
-    // iOS only: on Android auto-injected scripts load asynchronously and would
-    // double-inject the non-idempotent IITC core alongside the live fallback.
+    // Pre-register plugins as document-start scripts. On Android this requires
+    // addDocumentStartJavaScript support; without it the x-local async fallback would arrive
+    // after onLoadFinished and double-inject the non-idempotent IITC core.
     async registerPluginScripts() {
       const webview = this.webview;
-      if (!isIOS || !webview) return;
+      if (!webview) return;
+      if (!isIOS) {
+        if (!isAndroid) return;
+        try {
+          if (
+            !androidx.webkit.WebViewFeature.isFeatureSupported(
+              androidx.webkit.WebViewFeature.DOCUMENT_START_SCRIPT
+            )
+          )
+            return;
+        } catch {
+          return;
+        }
+      }
 
       // manager/run and handlePluginEvent can overlap.
       if (this.pluginRegistrationInProgress) {

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -19,7 +19,7 @@
 <script>
 import { injectBridgeIITC, writeBridgeScriptFile, router } from '@/utils/bridge';
 import { injectCustomStyles, installFileChooserOverride } from '~/utils/iitc-prime-resources';
-import { injectDebugBridge } from '@/utils/debug-bridge';
+import { injectDebugBridge, writeDebugBridgeFile } from '@/utils/debug-bridge';
 import BaseWebView from './BaseWebView.vue';
 import { addViewportParam, INGRESS_INTEL_MAP } from '@/utils/url-config';
 import { isIOS, Utils } from '@nativescript/core';
@@ -35,8 +35,27 @@ import {
   setSafeAreaInsets,
 } from '@/utils/events-to-iitc';
 
-// Resource name for the pre-registered bridge script
-const BRIDGE_SCRIPT_NAME = 'iitcBridge';
+// Scripts pre-registered to run at atDocumentEnd (iOS) so they are available
+// before the page finishes loading. `check` is evaluated at load finish to decide
+// whether the fallback `inject` is needed - always the case on Android, where
+// auto-injected scripts load asynchronously after the load event.
+const PRELOAD_SCRIPTS = [
+  {
+    name: 'iitcBridge',
+    write: writeBridgeScriptFile,
+    inject: injectBridgeIITC,
+    check: 'typeof window.app !== "undefined"',
+    // Content depends on runtime settings (zoom control), so it must be
+    // re-registered on reload. The other scripts are static.
+    dynamic: true,
+  },
+  {
+    name: 'iitcDebugBridge',
+    write: writeDebugBridgeFile,
+    inject: injectDebugBridge,
+    check: 'window.__debugBridgeInstalled === true',
+  },
+];
 
 export default {
   name: 'AppWebView',
@@ -147,17 +166,15 @@ export default {
       this.injectionInProgress = true;
 
       try {
-        // The bridge is normally provided by the pre-registered atDocumentEnd
-        // script. Inject it here only if it is not available yet - the case on
-        // Android, where the auto-injected script loads asynchronously after load.
-        const hasBridge = await this.webview.executeJavaScript('typeof window.app !== "undefined"');
-        if (hasBridge !== true) {
-          await injectBridgeIITC(this.webview);
+        // These are normally provided by the pre-registered atDocumentEnd scripts.
+        // Inject each here only if not available yet - the case on Android, where
+        // auto-injected scripts load asynchronously after the load event.
+        for (const script of PRELOAD_SCRIPTS) {
+          const present = await this.webview.executeJavaScript(script.check);
+          if (present !== true) {
+            await script.inject(this.webview);
+          }
         }
-        await injectDebugBridge(this.webview);
-
-        // Inject early so styles are active before IITC rewrites document.head
-        await injectCustomStyles(this.webview);
 
         this.lastInjectedUrl = urlWithoutHash;
         this.pendingInjectionUrl = null;
@@ -181,21 +198,24 @@ export default {
         }
       }
 
-      // Register the bridge as an atDocumentEnd script so it is available before
-      // the page finishes loading (iOS), instead of injecting it after load.
-      await this.registerBridgeScript(webview);
+      // Register the scripts as atDocumentEnd scripts so they are available before
+      // the page finishes loading (iOS), instead of injecting them after load.
+      await this.registerPreloadScripts(webview);
 
       this.$emit('webview-loaded', { webview });
     },
 
-    async registerBridgeScript(webview) {
+    async registerPreloadScripts(webview, { dynamicOnly = false } = {}) {
       if (!webview) return;
-      try {
-        const filePath = await writeBridgeScriptFile();
-        webview.removeAutoLoadJavaScriptFile(BRIDGE_SCRIPT_NAME);
-        await webview.autoLoadJavaScriptFile(BRIDGE_SCRIPT_NAME, filePath);
-      } catch (error) {
-        console.error('[AppWebView] Failed to register bridge script:', error);
+      for (const script of PRELOAD_SCRIPTS) {
+        if (dynamicOnly && !script.dynamic) continue;
+        try {
+          const filePath = await script.write();
+          webview.removeAutoLoadJavaScriptFile(script.name);
+          await webview.autoLoadJavaScriptFile(script.name, filePath);
+        } catch (error) {
+          console.error(`[AppWebView] Failed to register ${script.name}:`, error);
+        }
       }
     },
 
@@ -238,9 +258,10 @@ export default {
               this.pendingReloadUrl = addViewportParam(action.payload);
               webview.loadUrl('about:blank');
             } else {
-              // Re-register so settings changes are reflected
-              // in the bridge on the next load.
-              await this.registerBridgeScript(webview);
+              // Re-register only the settings-dependent script (bridge) so changes
+              // (e.g. zoom control) are reflected on the next load. Static scripts
+              // stay registered from the initial load.
+              await this.registerPreloadScripts(webview, { dynamicOnly: true });
               await this.$refs.baseWebView.reload();
             }
             break;

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -17,9 +17,23 @@
 </template>
 
 <script>
-import { injectBridgeIITC, writeBridgeScriptFile, router } from '@/utils/bridge';
+import {
+  injectBridgeIITC,
+  writeBridgeScriptFile,
+  injectPrimeParams,
+  writePrimeParamsFile,
+  router,
+} from '@/utils/bridge';
 import { injectCustomStyles, installFileChooserOverride } from '~/utils/iitc-prime-resources';
 import { injectDebugBridge, writeDebugBridgeFile } from '@/utils/debug-bridge';
+import {
+  writePluginScriptFile,
+  deletePluginScriptFile,
+  writePluginsMarkerFile,
+  pluginScriptName,
+  PLUGINS_MARKER_NAME,
+  PLUGINS_READY_FLAG,
+} from '@/utils/plugin-scripts';
 import BaseWebView from './BaseWebView.vue';
 import { addViewportParam, INGRESS_INTEL_MAP } from '@/utils/url-config';
 import { isIOS, Utils } from '@nativescript/core';
@@ -35,25 +49,30 @@ import {
   setSafeAreaInsets,
 } from '@/utils/events-to-iitc';
 
-// Scripts pre-registered to run at atDocumentEnd (iOS) so they are available
-// before the page finishes loading. `check` is evaluated at load finish to decide
-// whether the fallback `inject` is needed - always the case on Android, where
-// auto-injected scripts load asynchronously after the load event.
+// Scripts run as atDocumentEnd user scripts (iOS) before the page finishes loading.
+// On Android they load asynchronously, so `check` decides whether the fallback
+// `inject` is needed at load finish.
 const PRELOAD_SCRIPTS = [
   {
     name: 'iitcBridge',
     write: writeBridgeScriptFile,
     inject: injectBridgeIITC,
     check: 'typeof window.app !== "undefined"',
-    // Content depends on runtime settings (zoom control), so it must be
-    // re-registered on reload. The other scripts are static.
-    dynamic: true,
   },
   {
     name: 'iitcDebugBridge',
     write: writeDebugBridgeFile,
     inject: injectDebugBridge,
     check: 'window.__debugBridgeInstalled === true',
+  },
+  {
+    name: 'iitcPrimeParams',
+    write: writePrimeParamsFile,
+    inject: injectPrimeParams,
+    check: 'typeof window.__iitcShowZoom !== "undefined"',
+    // Re-registered on reload; re-registration moves a script to the end of the
+    // WKUserScript list, so only this settings-dependent entry is dynamic.
+    dynamic: true,
   },
 ];
 
@@ -166,9 +185,6 @@ export default {
       this.injectionInProgress = true;
 
       try {
-        // These are normally provided by the pre-registered atDocumentEnd scripts.
-        // Inject each here only if not available yet - the case on Android, where
-        // auto-injected scripts load asynchronously after the load event.
         for (const script of PRELOAD_SCRIPTS) {
           const present = await this.webview.executeJavaScript(script.check);
           if (present !== true) {
@@ -176,10 +192,18 @@ export default {
           }
         }
 
+        // Flag is set by the trailing marker user script after all plugins ran.
+        // Not set on iOS cold start (manager not ready yet) and never on Android.
+        const pluginsReady = await this.webview.executeJavaScript(
+          `window.${PLUGINS_READY_FLAG} === true`
+        );
+        if (pluginsReady !== true) {
+          await this.$store.dispatch('manager/inject');
+        }
+
         this.lastInjectedUrl = urlWithoutHash;
         this.pendingInjectionUrl = null;
 
-        // Then trigger plugin injection
         await this.$store.dispatch('ui/setWebviewLoaded', true);
       } catch (error) {
         console.error('[AppWebView] Bridge injection failed:', error);
@@ -198,9 +222,12 @@ export default {
         }
       }
 
-      // Register the scripts as atDocumentEnd scripts so they are available before
-      // the page finishes loading (iOS), instead of injecting them after load.
       await this.registerPreloadScripts(webview);
+
+      // Manager may have finished before the webview was ready.
+      if (this.$store.state.manager.isInitialized) {
+        await this.registerPluginScripts();
+      }
 
       this.$emit('webview-loaded', { webview });
     },
@@ -219,6 +246,54 @@ export default {
       }
     },
 
+    // iOS only: on Android auto-injected scripts load asynchronously and would
+    // double-inject the non-idempotent IITC core alongside the live fallback.
+    async registerPluginScripts() {
+      const webview = this.webview;
+      if (!isIOS || !webview) return;
+
+      // manager/run and handlePluginEvent can overlap.
+      if (this.pluginRegistrationInProgress) {
+        this.pluginRegistrationPending = true;
+        return;
+      }
+      this.pluginRegistrationInProgress = true;
+
+      try {
+        const scripts = await this.$store.dispatch('manager/getEnabledPluginScripts');
+        const newUids = scripts.map(s => s.uid);
+        const newUidSet = new Set(newUids);
+
+        for (const uid of this.registeredPluginUids) {
+          if (!newUidSet.has(uid)) {
+            webview.removeAutoLoadJavaScriptFile(pluginScriptName(uid));
+            await deletePluginScriptFile(uid);
+          }
+        }
+
+        for (const { uid, code } of scripts) {
+          const filePath = await writePluginScriptFile(uid, code);
+          webview.removeAutoLoadJavaScriptFile(pluginScriptName(uid));
+          await webview.autoLoadJavaScriptFile(pluginScriptName(uid), filePath);
+        }
+
+        // Marker last, so it runs after every plugin.
+        const markerPath = await writePluginsMarkerFile();
+        webview.removeAutoLoadJavaScriptFile(PLUGINS_MARKER_NAME);
+        await webview.autoLoadJavaScriptFile(PLUGINS_MARKER_NAME, markerPath);
+
+        this.registeredPluginUids = newUids;
+      } catch (error) {
+        console.error('[AppWebView] Failed to register plugin scripts:', error);
+      } finally {
+        this.pluginRegistrationInProgress = false;
+        if (this.pluginRegistrationPending) {
+          this.pluginRegistrationPending = false;
+          await this.registerPluginScripts();
+        }
+      }
+    },
+
     handleBridgeMessage(eventData) {
       router(eventData).catch(error => {
         console.error('[AppWebView] Bridge router error:', error.message, error.stack);
@@ -229,7 +304,6 @@ export default {
       this.$emit('console-log', logData);
     },
 
-    // Public method to execute debug command
     executeDebugCommand(command) {
       if (!this.$refs.baseWebView || !command) return;
       this.$refs.baseWebView.executeCommand(command);
@@ -247,20 +321,27 @@ export default {
   },
 
   created() {
+    // Non-reactive: avoid Vue observing large plugin code strings.
+    this.registeredPluginUids = [];
+    this.pluginRegistrationInProgress = false;
+    this.pluginRegistrationPending = false;
+
     this.store_unsubscribe = this.$store.subscribeAction({
       after: async (action, state) => {
         const webview = this.webview;
         if (!webview) return;
 
         switch (action.type) {
+          case 'manager/run':
+          case 'manager/handlePluginEvent':
+            await this.registerPluginScripts();
+            break;
           case 'ui/reloadWebView':
             if (action.payload) {
               this.pendingReloadUrl = addViewportParam(action.payload);
               webview.loadUrl('about:blank');
             } else {
-              // Re-register only the settings-dependent script (bridge) so changes
-              // (e.g. zoom control) are reflected on the next load. Static scripts
-              // stay registered from the initial load.
+              // Only re-register the dynamic script: static ones stay ordered before plugins.
               await this.registerPreloadScripts(webview, { dynamicOnly: true });
               await this.$refs.baseWebView.reload();
             }

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -122,6 +122,10 @@ export const manager = {
       return await managerService.inject();
     },
 
+    async getEnabledPluginScripts() {
+      return await managerService.getEnabledPluginScripts();
+    },
+
     /**
      * Load update channel into state
      */

--- a/app/store/modules/ui.js
+++ b/app/store/modules/ui.js
@@ -151,9 +151,6 @@ export const ui = {
         await dispatch('map/setMapStatus', null, { root: true });
         await dispatch('map/resetHighlighters', null, { root: true });
       }
-      if (status) {
-        await dispatch('manager/inject', null, { root: true });
-      }
     },
     setProgress({ commit }, progress) {
       commit('SET_PROGRESS', progress);

--- a/app/utils/bridge.js
+++ b/app/utils/bridge.js
@@ -163,8 +163,9 @@ const buildBridgeScript = () => {
       '};\n';
   });
   bridge +=
-    "window.nsWebViewBridge.getVersionName = function() {return '" + getVersionName() + "'};\n";
-  bridge += 'window.nsWebViewBridge.showZoom = function() {return ' + getZoomControl() + ';};\n';
+    'window.nsWebViewBridge.getVersionName = function() {return window.__iitcVersionName;};\n';
+  bridge +=
+    'window.nsWebViewBridge.showZoom = function() {return window.__iitcShowZoom === true;};\n';
 
   // async callback-based bridge functions
   Object.entries(asyncEvents).forEach(entry => {
@@ -222,4 +223,22 @@ export const writeBridgeScriptFile = async () => {
  */
 export const injectBridgeIITC = async webview => {
   await webview.executeJavaScript(buildBridgeScript());
+};
+
+const PRIME_PARAMS_FILENAME = 'prime-params.js';
+
+// Native -> web parameters. Separate from the bridge so the bridge stays static.
+// Add new parameters here; re-registration order is irrelevant for this script.
+const buildPrimeParamsScript = () =>
+  `window.__iitcVersionName = '${getVersionName()}';\n` +
+  `window.__iitcShowZoom = ${getZoomControl()};`;
+
+export const writePrimeParamsFile = async () => {
+  const filePath = path.join(knownFolders.documents().path, PRIME_PARAMS_FILENAME);
+  await File.fromPath(filePath).writeText(buildPrimeParamsScript());
+  return filePath;
+};
+
+export const injectPrimeParams = async webview => {
+  await webview.executeJavaScript(buildPrimeParamsScript());
 };

--- a/app/utils/bridge.js
+++ b/app/utils/bridge.js
@@ -21,6 +21,7 @@ import {
   shareString,
   gmBridgeRequest,
 } from '@/utils/events-from-iitc';
+import { File, knownFolders, path } from '@nativescript/core';
 
 export const router = async event => {
   const [eventName, eventData] = event;
@@ -106,7 +107,7 @@ export const router = async event => {
   }
 };
 
-export const injectBridgeIITC = async webview => {
+const buildBridgeScript = () => {
   let bridge = '';
 
   const events = {
@@ -163,8 +164,7 @@ export const injectBridgeIITC = async webview => {
   });
   bridge +=
     "window.nsWebViewBridge.getVersionName = function() {return '" + getVersionName() + "'};\n";
-  bridge +=
-    'window.nsWebViewBridge.showZoom = function() {return ' + getZoomControl() + ';};\n';
+  bridge += 'window.nsWebViewBridge.showZoom = function() {return ' + getZoomControl() + ';};\n';
 
   // async callback-based bridge functions
   Object.entries(asyncEvents).forEach(entry => {
@@ -201,5 +201,25 @@ export const injectBridgeIITC = async webview => {
   // Set window.app at the END, after all functions are defined
   bridge += 'window.app = window.nsWebViewBridge;\n';
 
-  await webview.executeJavaScript(bridge);
+  return bridge;
+};
+
+const BRIDGE_SCRIPT_FILENAME = 'iitc-bridge.js';
+
+/**
+ * Write the bridge script to a file for registration via autoLoadJavaScriptFile
+ * @returns {Promise<string>} Absolute path to the written file
+ */
+export const writeBridgeScriptFile = async () => {
+  const filePath = path.join(knownFolders.documents().path, BRIDGE_SCRIPT_FILENAME);
+  await File.fromPath(filePath).writeText(buildBridgeScript());
+  return filePath;
+};
+
+/**
+ * Inject the bridge directly via executeJavaScript.
+ * Fallback for when the pre-registered script is not yet available at load finish.
+ */
+export const injectBridgeIITC = async webview => {
+  await webview.executeJavaScript(buildBridgeScript());
 };

--- a/app/utils/debug-bridge.js
+++ b/app/utils/debug-bridge.js
@@ -1,11 +1,13 @@
 // Copyright (C) 2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
+import { File, knownFolders, path } from '@nativescript/core';
+
 /**
  * Debug bridge for WebView console interception
  * Provides console logging and JavaScript execution capabilities
  */
-export const injectDebugBridge = async webview => {
-  const script = `
+const buildDebugBridgeScript = () => {
+  return `
   (function() {
     function debugBridge() {
       if (window.__debugBridgeInstalled) return;
@@ -96,6 +98,24 @@ export const injectDebugBridge = async webview => {
     }
   })();
   `;
+};
 
-  await webview.executeJavaScript(script);
+const DEBUG_BRIDGE_SCRIPT_FILENAME = 'iitc-debug-bridge.js';
+
+/**
+ * Write the debug bridge script to a file for registration via autoLoadJavaScriptFile
+ * @returns {Promise<string>} Absolute path to the written file
+ */
+export const writeDebugBridgeFile = async () => {
+  const filePath = path.join(knownFolders.documents().path, DEBUG_BRIDGE_SCRIPT_FILENAME);
+  await File.fromPath(filePath).writeText(buildDebugBridgeScript());
+  return filePath;
+};
+
+/**
+ * Inject the debug bridge directly via executeJavaScript.
+ * Fallback for when the pre-registered script is not yet available at load finish.
+ */
+export const injectDebugBridge = async webview => {
+  await webview.executeJavaScript(buildDebugBridgeScript());
 };

--- a/app/utils/events-from-iitc.js
+++ b/app/utils/events-from-iitc.js
@@ -53,7 +53,7 @@ export const bootFinished = async name => {
  */
 export const switchToPane = async name => {
   if (store.state.navigation.currentPane !== name) {
-    await store.dispatch('navigation/setCurrentPane', name);
+    store.commit('navigation/SET_CURRENT_PANE', name);
   }
 };
 

--- a/app/utils/iitc-prime-resources.js
+++ b/app/utils/iitc-prime-resources.js
@@ -18,15 +18,15 @@ const getResourceContent = async filepath => {
 };
 
 /**
- * Inject custom CSS styles for IITC Prime
- * @remarks Page load (onLoadFinished), before IITC boot
+ * Inject custom CSS styles for IITC Prime.
+ * @remarks Injected after IITC boot - IITC replaces document.head on boot
  */
 export const injectCustomStyles = async webview => {
   try {
     const cssContent = await getResourceContent('~/assets/css/iitc-prime.css');
 
-    // Use nsWebViewBridge.injectStyleSheet directly
-    // loadStyleSheetFile doesn't work reliably, so we call the bridge method directly
+    // Use nsWebViewBridge.injectStyleSheet directly: loadStyleSheetFile doesn't
+    // work reliably, so we call the bridge method (idempotent by element id).
     const injectCssCode = `window.nsWebViewBridge.injectStyleSheet('iitcprimecss', ${JSON.stringify(cssContent)}, false);`;
 
     await webview.executeJavaScript(injectCssCode);

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -4,7 +4,7 @@
  * ManagerService - a service for working with lib-iitc-manager.
  */
 
-import { Manager } from 'lib-iitc-manager';
+import { Manager, wrapPluginCode, GM_API_UID } from 'lib-iitc-manager';
 import storage from '@/utils/storage';
 
 export class ManagerService {
@@ -125,6 +125,25 @@ export class ManagerService {
     const manager = await this.initialize();
     await manager.inject();
     return { success: true };
+  }
+
+  /**
+   * Returns the ordered plugin scripts (GM API, core, plugins) with final
+   * wrapped code, mirroring inject() but without invoking the callback.
+   * @returns {Promise<Array<{uid: string, code: string}>>}
+   */
+  async getEnabledPluginScripts() {
+    const manager = await this.initialize();
+    const plugins = await manager.getEnabledPlugins();
+    const scripts = [];
+    for (const uid in plugins) {
+      const plugin = plugins[uid];
+      if (!plugin || !plugin.code) continue;
+      // GM API component is injected as-is; everything else gets GM bindings.
+      const code = uid === GM_API_UID ? plugin.code : wrapPluginCode(plugin, manager.sourceUrlPrefix);
+      scripts.push({ uid, code });
+    }
+    return scripts;
   }
 
   // === Channel Management ===

--- a/app/utils/plugin-scripts.js
+++ b/app/utils/plugin-scripts.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+
+import { File, knownFolders, path } from '@nativescript/core';
+import { sanitizeFileName } from 'lib-iitc-manager';
+
+const PLUGINS_DIR = 'iitc-plugins';
+const MARKER_FILENAME = 'iitc-plugins-ready.js';
+
+// Registered last, after all plugin scripts, so the load-finish fallback can
+// tell whether the pre-registered plugins ran (skips live inject to avoid
+// double-injecting the non-idempotent IITC core).
+export const PLUGINS_MARKER_NAME = 'iitcPluginsReady';
+export const PLUGINS_READY_FLAG = '__iitcPluginsReady';
+
+const pluginsFolder = () => knownFolders.documents().getFolder(PLUGINS_DIR);
+const pluginFilePath = uid => path.join(pluginsFolder().path, `${sanitizeFileName(uid)}.js`);
+
+export const pluginScriptName = uid => `iitcPlugin:${uid}`;
+
+export const writePluginScriptFile = async (uid, code) => {
+  const filePath = pluginFilePath(uid);
+  await File.fromPath(filePath).writeText(code);
+  return filePath;
+};
+
+export const deletePluginScriptFile = async uid => {
+  const filePath = pluginFilePath(uid);
+  if (File.exists(filePath)) {
+    await File.fromPath(filePath).remove();
+  }
+};
+
+export const writePluginsMarkerFile = async () => {
+  const filePath = path.join(knownFolders.documents().path, MARKER_FILENAME);
+  await File.fromPath(filePath).writeText(`window.${PLUGINS_READY_FLAG} = true;`);
+  return filePath;
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@bezlepkin/nativescript-keyboard-opening": "^1.0.1",
-    "@modos189/nativescript-webview-x": "^1.0.1",
+    "@modos189/nativescript-webview-x": "^1.1.0",
     "@nativescript-community/fonticon": "^3.0.0",
     "@nativescript-community/gps": "^3.1.10",
     "@nativescript-community/l": "^4.3.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iitc-prime",
   "main": "app/app.js",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "scripts": {
     "run:android": "ns run android",


### PR DESCRIPTION
Significantly speeds up IITC startup by injecting the bridge and plugins at DOMContentLoaded instead of waiting for the full page load to finish.

Scripts are pre-registered as user scripts that run on every navigation:
- **iOS**: `WKUserScript atDocumentEnd` via `autoLoadJavaScriptFile`
- **Android**: `WebViewCompat.addDocumentStartJavaScript` (requires DOCUMENT_START_SCRIPT support in the installed WebView provider; falls back to the existing post-load injection otherwise)

The bridge is kept fully static (no runtime interpolations); dynamic parameters (`getVersionName`, `showZoom`) are separated into a `prime-params` script re-registered only when settings change.

On warm start `pluginsReady` is true and `manager/inject` is skipped.
On cold start the existing fallback path runs as before.

Requires Android `minSdkVersion 24`