### PR TITLE
perf(manager): run lib-iitc-manager in a background Worker

### DIFF
--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -27,7 +27,6 @@ import {
 import { injectCustomStyles, installFileChooserOverride } from '~/utils/iitc-prime-resources';
 import { injectDebugBridge, writeDebugBridgeFile } from '@/utils/debug-bridge';
 import {
-  writePluginScriptFile,
   deletePluginScriptFile,
   writePluginsMarkerFile,
   pluginScriptName,
@@ -283,8 +282,7 @@ export default {
           }
         }
 
-        for (const { uid, code } of scripts) {
-          const filePath = await writePluginScriptFile(uid, code);
+        for (const { uid, filePath } of scripts) {
           webview.removeAutoLoadJavaScriptFile(pluginScriptName(uid));
           await webview.autoLoadJavaScriptFile(pluginScriptName(uid), filePath);
         }

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -337,6 +337,15 @@ export default {
         console.error(`Plugin ${plugin.uid} injection failed:`, error);
       }
     },
+
+    async performReload() {
+      const webview = this.webview;
+      if (!webview) return;
+      if (this.pluginRegistrationPromise) await this.pluginRegistrationPromise;
+      // Only re-register the dynamic script: static ones stay ordered before plugins.
+      await this.registerPreloadScripts(webview, { dynamicOnly: true });
+      await this.$refs.baseWebView.reload();
+    },
   },
 
   created() {
@@ -344,6 +353,19 @@ export default {
     this.registeredPluginUids = [];
     this.pluginRegistrationPromise = null;
     this.pluginRegistrationPending = false;
+    this.reloadPending = false;
+
+    this.mainPageActive_unwatch = this.$watch(
+      () => this.$store.state.ui.isMainPageFocused,
+      active => {
+        if (active && this.reloadPending) {
+          this.reloadPending = false;
+          this.performReload().catch(error => {
+            console.error('[AppWebView] Deferred reload failed:', error);
+          });
+        }
+      }
+    );
 
     this.store_unsubscribe = this.$store.subscribeAction({
       after: async (action, state) => {
@@ -359,12 +381,10 @@ export default {
             if (action.payload) {
               this.pendingReloadUrl = addViewportParam(action.payload);
               webview.loadUrl('about:blank');
+            } else if (this.$store.state.ui.isMainPageFocused) {
+              await this.performReload();
             } else {
-              // Await in-flight registration so the page reloads with current scripts.
-              if (this.pluginRegistrationPromise) await this.pluginRegistrationPromise;
-              // Only re-register the dynamic script: static ones stay ordered before plugins.
-              await this.registerPreloadScripts(webview, { dynamicOnly: true });
-              await this.$refs.baseWebView.reload();
+              this.reloadPending = true;
             }
             break;
           case 'ui/iitcBootFinished': {
@@ -435,6 +455,7 @@ export default {
 
   beforeUnmount() {
     this.store_unsubscribe();
+    this.mainPageActive_unwatch?.();
   },
 };
 </script>

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -29,6 +29,7 @@ import { injectDebugBridge, writeDebugBridgeFile } from '@/utils/debug-bridge';
 import {
   deletePluginScriptFile,
   writePluginsMarkerFile,
+  readPluginScriptCode,
   pluginScriptName,
   PLUGINS_MARKER_NAME,
   PLUGINS_READY_FLAG,
@@ -195,7 +196,7 @@ export default {
           `window.${PLUGINS_READY_FLAG} === true`
         );
         if (pluginsReady !== true) {
-          await this.$store.dispatch('manager/inject');
+          await this.injectEnabledPlugins();
         }
 
         this.lastInjectedUrl = urlWithoutHash;
@@ -328,13 +329,20 @@ export default {
       this.$refs.baseWebView.executeCommand(command);
     },
 
+    async injectEnabledPlugins() {
+      const scripts = await this.$store.dispatch('manager/getEnabledPluginScripts');
+      for (const script of scripts) {
+        await this.injectPlugin(script);
+      }
+    },
+
     async injectPlugin(plugin) {
-      if (!this.webview || !plugin?.code) return;
+      if (!this.webview || !plugin?.filePath) return;
       try {
-        await this.webview.executeJavaScript(plugin.code, false);
-        console.log(`Plugin ${plugin.uid} loaded`);
+        const code = await readPluginScriptCode(plugin.filePath);
+        await this.webview.executeJavaScript(code, false);
       } catch (error) {
-        console.error(`Plugin ${plugin.uid} injection failed:`, error);
+        console.error(`[AppWebView] Plugin ${plugin.uid} injection failed:`, error);
       }
     },
 

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -246,7 +246,7 @@ export default {
     // Pre-register plugins as document-start scripts. On Android this requires
     // addDocumentStartJavaScript support; without it the x-local async fallback would arrive
     // after onLoadFinished and double-inject the non-idempotent IITC core.
-    async registerPluginScripts() {
+    registerPluginScripts() {
       const webview = this.webview;
       if (!webview) return;
       if (!isIOS) {
@@ -263,12 +263,27 @@ export default {
         }
       }
 
-      // manager/run and handlePluginEvent can overlap.
-      if (this.pluginRegistrationInProgress) {
+      // manager/run and handlePluginEvent can overlap; coalesce into one run.
+      if (this.pluginRegistrationPromise) {
         this.pluginRegistrationPending = true;
-        return;
+        return this.pluginRegistrationPromise;
       }
-      this.pluginRegistrationInProgress = true;
+      this.pluginRegistrationPromise = this._runPluginRegistration().finally(() => {
+        this.pluginRegistrationPromise = null;
+      });
+      return this.pluginRegistrationPromise;
+    },
+
+    async _runPluginRegistration() {
+      do {
+        this.pluginRegistrationPending = false;
+        await this._registerPluginScriptsOnce();
+      } while (this.pluginRegistrationPending);
+    },
+
+    async _registerPluginScriptsOnce() {
+      const webview = this.webview;
+      if (!webview) return;
 
       try {
         const scripts = await this.$store.dispatch('manager/getEnabledPluginScripts');
@@ -295,12 +310,6 @@ export default {
         this.registeredPluginUids = newUids;
       } catch (error) {
         console.error('[AppWebView] Failed to register plugin scripts:', error);
-      } finally {
-        this.pluginRegistrationInProgress = false;
-        if (this.pluginRegistrationPending) {
-          this.pluginRegistrationPending = false;
-          await this.registerPluginScripts();
-        }
       }
     },
 
@@ -333,7 +342,7 @@ export default {
   created() {
     // Non-reactive: avoid Vue observing large plugin code strings.
     this.registeredPluginUids = [];
-    this.pluginRegistrationInProgress = false;
+    this.pluginRegistrationPromise = null;
     this.pluginRegistrationPending = false;
 
     this.store_unsubscribe = this.$store.subscribeAction({
@@ -351,6 +360,8 @@ export default {
               this.pendingReloadUrl = addViewportParam(action.payload);
               webview.loadUrl('about:blank');
             } else {
+              // Await in-flight registration so the page reloads with current scripts.
+              if (this.pluginRegistrationPromise) await this.pluginRegistrationPromise;
               // Only re-register the dynamic script: static ones stay ordered before plugins.
               await this.registerPreloadScripts(webview, { dynamicOnly: true });
               await this.$refs.baseWebView.reload();

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -6,6 +6,8 @@
       actionBarHidden="true"
       androidOverflowEdge="dont-apply"
       @androidOverflowInset="onAndroidInset"
+      @navigatedTo="onMainPageNavigatedTo"
+      @navigatingFrom="onMainPageNavigatingFrom"
     >
       <RootLayout ref="rootLayout" height="100%" width="100%" @layoutChanged="onRootLayoutChanged">
         <BottomSheetPanel
@@ -371,6 +373,14 @@ export default {
     isMainPageActive() {
       const frame = Frame.topmost();
       return !frame?.backStack?.length;
+    },
+
+    onMainPageNavigatedTo() {
+      this.$store.dispatch('ui/setMainPageFocused', true);
+    },
+
+    onMainPageNavigatingFrom() {
+      this.$store.dispatch('ui/setMainPageFocused', false);
     },
 
     onKeyboardOpened(args) {

--- a/app/store/modules/manager.js
+++ b/app/store/modules/manager.js
@@ -115,13 +115,6 @@ export const manager = {
       }
     },
 
-    /**
-     * Inject plugins
-     */
-    async inject() {
-      return await managerService.inject();
-    },
-
     async getEnabledPluginScripts() {
       return await managerService.getEnabledPluginScripts();
     },

--- a/app/store/modules/ui.js
+++ b/app/store/modules/ui.js
@@ -39,6 +39,8 @@ export const ui = {
 
     isKeyboardOpen: false,
 
+    isMainPageFocused: true,
+
     // Pending plugin to install (from file intent or URL)
     // { type: 'url', value: '...' } or { type: 'file', code: '...', filename: '...' }
     pendingPlugin: null,
@@ -128,6 +130,10 @@ export const ui = {
       state.pendingPlugin = plugin;
     },
 
+    SET_MAIN_PAGE_FOCUSED(state, active) {
+      state.isMainPageFocused = active;
+    },
+
     SET_SCREEN_SAFE_AREA(state, { top, bottom, left, right } = {}) {
       if (top !== undefined) state.screenSafeArea.top = top;
       if (bottom !== undefined) state.screenSafeArea.bottom = bottom;
@@ -156,6 +162,9 @@ export const ui = {
       commit('SET_PROGRESS', progress);
     },
     reloadWebView() {},
+    setMainPageFocused({ commit }, active) {
+      commit('SET_MAIN_PAGE_FOCUSED', active);
+    },
     setIitcLoaded({ commit }, status) {
       commit('SET_IITC_LOADED', status);
     },

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -97,10 +97,6 @@ export class ManagerService {
     return this._call('checkUpdates', force);
   }
 
-  async inject() {
-    return this._call('inject');
-  }
-
   /** @returns {Promise<Array<{uid: string, filePath: string}>>} */
   async getEnabledPluginScripts() {
     return this._call('getEnabledPluginScripts');

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -101,7 +101,7 @@ export class ManagerService {
     return this._call('inject');
   }
 
-  /** @returns {Promise<Array<{uid: string, code: string}>>} */
+  /** @returns {Promise<Array<{uid: string, filePath: string}>>} */
   async getEnabledPluginScripts() {
     return this._call('getEnabledPluginScripts');
   }
@@ -132,10 +132,6 @@ export class ManagerService {
 
   async getPlugins() {
     return this._call('getPlugins');
-  }
-
-  async getEnabledPlugins() {
-    return this._call('getEnabledPlugins');
   }
 
   async managePlugin(uid, action) {

--- a/app/utils/manager-service.js
+++ b/app/utils/manager-service.js
@@ -2,15 +2,18 @@
 
 /**
  * ManagerService - a service for working with lib-iitc-manager.
+ *
+ * Runs lib-iitc-manager on a background Worker (manager-worker.js) and exposes
+ * the same async API. Heavy work (plugin parsing, update fetching) runs off the
+ * UI thread.
  */
-
-import { Manager, wrapPluginCode, GM_API_UID } from 'lib-iitc-manager';
-import storage from '@/utils/storage';
 
 export class ManagerService {
   constructor() {
-    this.manager = null;
-    this.isInitialized = false;
+    this.worker = null;
+    this.nextId = 1;
+    // id -> { resolve, reject } for in-flight RPC calls
+    this.pending = new Map();
     this.callbacks = {
       onMessage: null,
       onProgress: null,
@@ -20,235 +23,139 @@ export class ManagerService {
     };
   }
 
-  /**
-   * Initialize Manager instance
-   */
-  async initialize() {
-    if (this.isInitialized && this.manager) {
-      return this.manager;
-    }
+  _ensureWorker() {
+    if (this.worker) return this.worker;
 
-    try {
-      this.manager = new Manager({
-        storage: {
-          async get(keys) {
-            return await storage.get(keys);
-          },
-          async set(obj) {
-            await storage.set(obj);
-          },
-        },
-        gmApi: {
-          bridgeAdapterCode: `
-            window.__iitc_gm_bridge__ = {
-              send(data) {
-                window.nsWebViewBridge.emit('gmBridgeRequest', JSON.stringify(data));
-              },
-              onResponse(cb) {
-                window.addEventListener('gmBridgeResponse', function(e) { cb(e.detail); });
-              }
-            };
-          `,
-        },
-        message: (message, args) => {
-          console.log(`[ManagerService] message: ${message}`, args);
-          if (this.callbacks.onMessage) {
-            this.callbacks.onMessage(message, args);
-          }
-        },
-        onProgress: isShow => {
-          if (this.callbacks.onProgress) {
-            this.callbacks.onProgress(isShow);
-          }
-        },
-        injectPlugin: plugin => {
-          if (this.callbacks.onInjectPlugin) {
-            this.callbacks.onInjectPlugin(plugin);
-          }
-        },
-        onPluginEvent: event => {
-          if (this.callbacks.onPluginEvent) {
-            this.callbacks.onPluginEvent(event);
-          }
-        },
-        onPluginsViewChanged: view => {
-          if (this.callbacks.onPluginsViewChanged) {
-            this.callbacks.onPluginsViewChanged(view.plugins, view.core || null);
-          }
-        },
-        useFetchHeadMethod: false,
-        isDaemon: false,
-      });
+    // String literal is required: nativescript-worker-loader rewrites it into a
+    // bundled worker chunk at build time.
+    this.worker = new Worker('./manager-worker.js');
 
-      this.isInitialized = true;
-      return this.manager;
-    } catch (error) {
-      console.error('[ManagerService] Failed to initialize Manager:', error);
-      throw error;
-    }
+    this.worker.onmessage = msg => {
+      const data = msg.data || {};
+
+      // Manager callback forwarded from the worker
+      if (data.callback) {
+        this._dispatchCallback(data.callback, data.args || []);
+        return;
+      }
+
+      // RPC response
+      const entry = this.pending.get(data.id);
+      if (!entry) return;
+      this.pending.delete(data.id);
+
+      if (data.error) {
+        const error = new Error(data.error.message);
+        if (data.error.name) error.name = data.error.name;
+        if (data.error.stack) error.stack = data.error.stack;
+        entry.reject(error);
+      } else {
+        entry.resolve(data.result);
+      }
+    };
+
+    this.worker.onerror = error => {
+      console.error('[ManagerService] Worker error:', error);
+      // A fatal worker error means in-flight RPCs will never get a response;
+      // reject them so callers don't hang. (Per-call errors are reported as
+      // { id, error } messages and handled above, not here.)
+      this._rejectAllPending(new Error(`Manager worker error: ${error?.message || error}`));
+    };
+
+    return this.worker;
   }
 
-  // === Core Operations ===
+  _rejectAllPending(error) {
+    for (const entry of this.pending.values()) {
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
 
-  /**
-   * Start Manager and load initial data
-   */
+  _call(method, ...args) {
+    const worker = this._ensureWorker();
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      worker.postMessage({ id, method, args });
+    });
+  }
+
+  _dispatchCallback(name, args) {
+    const cb = this.callbacks[name];
+    if (name === 'onMessage') {
+      console.log(`[ManagerService] message: ${args[0]}`, args[1]);
+    }
+    if (cb) cb(...args);
+  }
+
   async startup() {
-    const manager = await this.initialize();
-    await manager.run();
-
-    const [channel, customUrl] = await Promise.all([
-      this.getUpdateChannel(),
-      this.getCustomChannelUrl(),
-    ]);
-
-    return {
-      isRunning: true,
-      currentChannel: channel,
-      customChannelUrl: customUrl,
-    };
+    return this._call('startup');
   }
 
-  /**
-   * Update check
-   */
   async checkUpdates(force = false) {
-    const manager = await this.initialize();
-    await manager.checkUpdates(force);
-    return { success: true };
+    return this._call('checkUpdates', force);
   }
 
-  /**
-   * Inject plugins
-   */
   async inject() {
-    const manager = await this.initialize();
-    await manager.inject();
-    return { success: true };
+    return this._call('inject');
   }
 
-  /**
-   * Returns the ordered plugin scripts (GM API, core, plugins) with final
-   * wrapped code, mirroring inject() but without invoking the callback.
-   * @returns {Promise<Array<{uid: string, code: string}>>}
-   */
+  /** @returns {Promise<Array<{uid: string, code: string}>>} */
   async getEnabledPluginScripts() {
-    const manager = await this.initialize();
-    const plugins = await manager.getEnabledPlugins();
-    const scripts = [];
-    for (const uid in plugins) {
-      const plugin = plugins[uid];
-      if (!plugin || !plugin.code) continue;
-      // GM API component is injected as-is; everything else gets GM bindings.
-      const code = uid === GM_API_UID ? plugin.code : wrapPluginCode(plugin, manager.sourceUrlPrefix);
-      scripts.push({ uid, code });
-    }
-    return scripts;
+    return this._call('getEnabledPluginScripts');
   }
 
-  // === Channel Management ===
-
-  /**
-   * Get current update channel
-   */
   async getUpdateChannel() {
-    const manager = await this.initialize();
-    return manager.channel;
+    return this._call('getUpdateChannel');
   }
 
-  /**
-   * Set update channel and reload plugins
-   */
   async setUpdateChannel(channel) {
-    const manager = await this.initialize();
-    await manager.setChannel(channel);
-    return { currentChannel: channel };
+    return this._call('setUpdateChannel', channel);
   }
 
-  /**
-   * Get update check interval
-   */
   async getUpdateInterval(channel) {
-    const manager = await this.initialize();
-    return await manager.getUpdateCheckInterval(channel);
+    return this._call('getUpdateInterval', channel);
   }
 
-  /**
-   * Set update check interval
-   */
   async setUpdateInterval(interval, channel) {
-    const manager = await this.initialize();
-    await manager.setUpdateCheckInterval(interval, channel);
-    return { success: true };
+    return this._call('setUpdateInterval', interval, channel);
   }
 
-  /**
-   * Get custom channel URL
-   */
   async getCustomChannelUrl() {
-    const manager = await this.initialize();
-    return manager.networkHost?.custom ?? '';
+    return this._call('getCustomChannelUrl');
   }
 
-  /**
-   * Set custom channel URL
-   */
   async setCustomChannelUrl(url) {
-    const manager = await this.initialize();
-    await manager.setCustomChannelUrl(url);
-    return {
-      customChannelUrl: url,
-    };
+    return this._call('setCustomChannelUrl', url);
   }
 
-  // === Plugin Management ===
-
-  /**
-   * Get all plugins
-   */
   async getPlugins() {
-    const manager = await this.initialize();
-    const view = await manager.getPluginsView();
-    return { plugins: view.plugins, core: view.core || null };
+    return this._call('getPlugins');
   }
 
-  /**
-   * Get only enabled plugins
-   */
   async getEnabledPlugins() {
-    const manager = await this.initialize();
-    return await manager.getEnabledPlugins();
+    return this._call('getEnabledPlugins');
   }
 
-  /**
-   * Enable/disable plugin
-   */
   async managePlugin(uid, action) {
-    const manager = await this.initialize();
-    await manager.managePlugin(uid, action);
+    await this._call('managePlugin', uid, action);
   }
 
-  /**
-   * Add user scripts
-   */
   async addUserScripts(scripts) {
-    const manager = await this.initialize();
-    return await manager.addUserScripts(scripts);
+    return this._call('addUserScripts', scripts);
   }
 
-  /**
-   * Set callback functions for handling Manager events
-   */
   setCallbacks(callbacks) {
     this.callbacks = { ...this.callbacks, ...callbacks };
   }
 
-  /**
-   * Cleanup resources
-   */
   cleanup() {
-    this.manager = null;
-    this.isInitialized = false;
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this._rejectAllPending(new Error('ManagerService cleaned up'));
     this.callbacks = {
       onMessage: null,
       onProgress: null,

--- a/app/utils/manager-worker.js
+++ b/app/utils/manager-worker.js
@@ -1,0 +1,187 @@
+// Copyright (C) 2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+
+/**
+ * manager-worker - runs lib-iitc-manager on a background thread.
+ *
+ * The real Manager instance lives here so its heavy work (plugin parsing,
+ * wrapPluginCode, update fetching) does not block the single UI thread.
+ * The main thread talks to it through a small RPC protocol via postMessage:
+ *
+ *   main -> worker:  { id, method, args }
+ *   worker -> main:  { id, result }                (resolves the RPC promise)
+ *                    { id, error }                 (rejects the RPC promise)
+ *                    { callback, args }            (a Manager callback fired)
+ *
+ * Note: NativeScript workers pass JSON-serializable data by copy only -
+ * no shared memory, no ArrayBuffer transfer.
+ */
+
+import '@nativescript/core/globals';
+import { Manager, wrapPluginCode, GM_API_UID } from 'lib-iitc-manager';
+import storage from '@/utils/storage';
+
+// Worker global scope (NativeScript exposes onmessage/postMessage on global).
+const ctx = global;
+
+let manager = null;
+
+const emitCallback = (callback, args) => {
+  ctx.postMessage({ callback, args });
+};
+
+const getManager = () => {
+  if (manager) {
+    return manager;
+  }
+
+  manager = new Manager({
+    storage: {
+      async get(keys) {
+        return await storage.get(keys);
+      },
+      async set(obj) {
+        await storage.set(obj);
+      },
+    },
+    gmApi: {
+      bridgeAdapterCode: `
+        window.__iitc_gm_bridge__ = {
+          send(data) {
+            window.nsWebViewBridge.emit('gmBridgeRequest', JSON.stringify(data));
+          },
+          onResponse(cb) {
+            window.addEventListener('gmBridgeResponse', function(e) { cb(e.detail); });
+          }
+        };
+      `,
+    },
+    message: (message, args) => {
+      emitCallback('onMessage', [message, args]);
+    },
+    onProgress: isShow => {
+      emitCallback('onProgress', [isShow]);
+    },
+    injectPlugin: plugin => {
+      emitCallback('onInjectPlugin', [plugin]);
+    },
+    onPluginEvent: event => {
+      emitCallback('onPluginEvent', [event]);
+    },
+    onPluginsViewChanged: view => {
+      emitCallback('onPluginsViewChanged', [view.plugins, view.core || null]);
+    },
+    useFetchHeadMethod: false,
+    isDaemon: false,
+  });
+
+  return manager;
+};
+
+const handlers = {
+  async startup() {
+    const m = getManager();
+    await m.run();
+    const channel = m.channel;
+    const customUrl = m.networkHost?.custom ?? '';
+    return { isRunning: true, currentChannel: channel, customChannelUrl: customUrl };
+  },
+
+  async checkUpdates(force = false) {
+    await getManager().checkUpdates(force);
+    return { success: true };
+  },
+
+  async inject() {
+    await getManager().inject();
+    return { success: true };
+  },
+
+  async getEnabledPluginScripts() {
+    const m = getManager();
+    const plugins = await m.getEnabledPlugins();
+    const scripts = [];
+    for (const uid in plugins) {
+      const plugin = plugins[uid];
+      if (!plugin || !plugin.code) continue;
+      // GM API component is injected as-is; everything else gets GM bindings.
+      const code = uid === GM_API_UID ? plugin.code : wrapPluginCode(plugin, m.sourceUrlPrefix);
+      scripts.push({ uid, code });
+    }
+    return scripts;
+  },
+
+  async getUpdateChannel() {
+    return getManager().channel;
+  },
+
+  async setUpdateChannel(channel) {
+    await getManager().setChannel(channel);
+    return { currentChannel: channel };
+  },
+
+  async getUpdateInterval(channel) {
+    return await getManager().getUpdateCheckInterval(channel);
+  },
+
+  async setUpdateInterval(interval, channel) {
+    await getManager().setUpdateCheckInterval(interval, channel);
+    return { success: true };
+  },
+
+  async getCustomChannelUrl() {
+    return getManager().networkHost?.custom ?? '';
+  },
+
+  async setCustomChannelUrl(url) {
+    await getManager().setCustomChannelUrl(url);
+    return { customChannelUrl: url };
+  },
+
+  async getPlugins() {
+    const view = await getManager().getPluginsView();
+    return { plugins: view.plugins, core: view.core || null };
+  },
+
+  async getEnabledPlugins() {
+    return await getManager().getEnabledPlugins();
+  },
+
+  async managePlugin(uid, action) {
+    await getManager().managePlugin(uid, action);
+    return { success: true };
+  },
+
+  async addUserScripts(scripts) {
+    return await getManager().addUserScripts(scripts);
+  },
+};
+
+ctx.onmessage = async msg => {
+  const { id, method, args = [] } = msg.data || {};
+  const handler = handlers[method];
+
+  if (!handler) {
+    ctx.postMessage({ id, error: { message: `Unknown manager method: ${method}` } });
+    return;
+  }
+
+  try {
+    const result = await handler(...args);
+    ctx.postMessage({ id, result });
+  } catch (error) {
+    ctx.postMessage({
+      id,
+      error: {
+        message: error?.message || String(error),
+        name: error?.name,
+        stack: error?.stack,
+      },
+    });
+  }
+};
+
+ctx.onerror = error => {
+  console.error('[ManagerWorker] Uncaught error:', error);
+  // Returning true marks the error as handled so the worker is not torn down.
+  return true;
+};

--- a/app/utils/manager-worker.js
+++ b/app/utils/manager-worker.js
@@ -13,9 +13,9 @@
  *                    { callback, args }            (a Manager callback fired)
  *
  * Note: NativeScript workers pass JSON-serializable data by copy only.
- * Plugin code never crosses the boundary: getEnabledPluginScripts writes
- * scripts to disk and returns paths; getPlugins / onPluginsViewChanged strip
- * `code` from metadata. Only onInjectPlugin (cold-start fallback) carries code.
+ * Plugin code never crosses the boundary: getEnabledPluginScripts and the
+ * injectPlugin callback both write scripts to disk and return paths; getPlugins
+ * / onPluginsViewChanged strip `code` from metadata.
  */
 
 import '@nativescript/core/globals';
@@ -76,8 +76,11 @@ const getManager = () => {
     onProgress: isShow => {
       emitCallback('onProgress', [isShow]);
     },
-    injectPlugin: plugin => {
-      emitCallback('onInjectPlugin', [plugin]);
+    injectPlugin: async plugin => {
+      // Write to disk so plugin code never crosses the worker boundary via postMessage
+      if (!plugin || !plugin.code) return;
+      const filePath = await writePluginScriptFile(plugin.uid, plugin.code);
+      emitCallback('onInjectPlugin', [{ uid: plugin.uid, filePath }]);
     },
     onPluginEvent: event => {
       emitCallback('onPluginEvent', [event]);
@@ -106,11 +109,6 @@ const handlers = {
 
   async checkUpdates(force = false) {
     await getManager().checkUpdates(force);
-    return { success: true };
-  },
-
-  async inject() {
-    await getManager().inject();
     return { success: true };
   },
 

--- a/app/utils/manager-worker.js
+++ b/app/utils/manager-worker.js
@@ -12,18 +12,33 @@
  *                    { id, error }                 (rejects the RPC promise)
  *                    { callback, args }            (a Manager callback fired)
  *
- * Note: NativeScript workers pass JSON-serializable data by copy only -
- * no shared memory, no ArrayBuffer transfer.
+ * Note: NativeScript workers pass JSON-serializable data by copy only.
+ * Plugin code never crosses the boundary: getEnabledPluginScripts writes
+ * scripts to disk and returns paths; getPlugins / onPluginsViewChanged strip
+ * `code` from metadata. Only onInjectPlugin (cold-start fallback) carries code.
  */
 
 import '@nativescript/core/globals';
 import { Manager, wrapPluginCode, GM_API_UID } from 'lib-iitc-manager';
 import storage from '@/utils/storage';
+import { writePluginScriptFile } from '@/utils/plugin-scripts';
 
 // Worker global scope (NativeScript exposes onmessage/postMessage on global).
 const ctx = global;
 
 let manager = null;
+
+const stripCode = plugin => {
+  if (!plugin) return plugin;
+  const { code, ...meta } = plugin;
+  return meta;
+};
+
+const stripCodeMap = plugins => {
+  const out = {};
+  for (const uid in plugins) out[uid] = stripCode(plugins[uid]);
+  return out;
+};
 
 const emitCallback = (callback, args) => {
   ctx.postMessage({ callback, args });
@@ -68,7 +83,10 @@ const getManager = () => {
       emitCallback('onPluginEvent', [event]);
     },
     onPluginsViewChanged: view => {
-      emitCallback('onPluginsViewChanged', [view.plugins, view.core || null]);
+      emitCallback('onPluginsViewChanged', [
+        stripCodeMap(view.plugins),
+        stripCode(view.core) || null,
+      ]);
     },
     useFetchHeadMethod: false,
     isDaemon: false,
@@ -105,7 +123,8 @@ const handlers = {
       if (!plugin || !plugin.code) continue;
       // GM API component is injected as-is; everything else gets GM bindings.
       const code = uid === GM_API_UID ? plugin.code : wrapPluginCode(plugin, m.sourceUrlPrefix);
-      scripts.push({ uid, code });
+      const filePath = await writePluginScriptFile(uid, code);
+      scripts.push({ uid, filePath });
     }
     return scripts;
   },
@@ -139,11 +158,7 @@ const handlers = {
 
   async getPlugins() {
     const view = await getManager().getPluginsView();
-    return { plugins: view.plugins, core: view.core || null };
-  },
-
-  async getEnabledPlugins() {
-    return await getManager().getEnabledPlugins();
+    return { plugins: stripCodeMap(view.plugins), core: stripCode(view.core) || null };
   },
 
   async managePlugin(uid, action) {

--- a/app/utils/plugin-scripts.js
+++ b/app/utils/plugin-scripts.js
@@ -23,6 +23,8 @@ export const writePluginScriptFile = async (uid, code) => {
   return filePath;
 };
 
+export const readPluginScriptCode = async filePath => File.fromPath(filePath).readText();
+
 export const deletePluginScriptFile = async uid => {
   const filePath = pluginFilePath(uid);
   if (File.exists(filePath)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iitc-prime",
   "main": "app/app.js",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "scripts": {
     "run:android": "ns run android",


### PR DESCRIPTION
Moves lib-iitc-manager off the UI thread into a NativeScript Worker so plugin parsing, code wrapping, and update fetching no longer block rendering.

- **Worker + RPC proxy** - the real `Manager` runs in `manager-worker.js`; `ManagerService` is now a thin RPC proxy with the same async API, so callers (Vuex, AppWebView) are unchanged. Fatal worker errors reject in-flight calls.
- **Keep the boundary cheap** - plugin code never crosses it: scripts are wrapped and written to disk in the worker (only paths returned), and `getPlugins`/`onPluginsViewChanged` strip `code` from metadata.
- **Coalesce plugin registration** - concurrent registrations share one promise so a reload can await the latest scripts instead of double-injecting.
- **Defer reload until navigation settles** - WebView reloads requested from a sub-screen wait for the main page to foreground, avoiding an iOS Frame crash during screen transitions.