### PR TITLE
feat: native file import and fix iOS file export

### DIFF
--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -22,6 +22,12 @@
     <string>175353347</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>IITC Prime can show your current position on the Ingress intel map. Location access is optional.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Lets you take a photo when a map page asks to import a file</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Lets you record a video when a map page asks to import a file</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Lets you attach a photo from your library when a map page asks to import a file</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UILaunchStoryboardName</key>

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -24,7 +24,7 @@ import {
   writePrimeParamsFile,
   router,
 } from '@/utils/bridge';
-import { injectCustomStyles, installFileChooserOverride } from '~/utils/iitc-prime-resources';
+import { injectCustomStyles } from '~/utils/iitc-prime-resources';
 import { injectDebugBridge, writeDebugBridgeFile } from '@/utils/debug-bridge';
 import {
   deletePluginScriptFile,
@@ -396,7 +396,6 @@ export default {
             }
             break;
           case 'ui/iitcBootFinished': {
-            await installFileChooserOverride(webview);
             // Re-inject after IITC boot since document.head was replaced
             await injectCustomStyles(webview);
             // Set initial safe area insets after IITC loads

--- a/app/utils/bridge.js
+++ b/app/utils/bridge.js
@@ -16,7 +16,6 @@ import {
   addInternalHostname,
   setFollowMode,
   saveFile,
-  chooseFiles,
   copyToClipboardBridge,
   shareString,
   gmBridgeRequest,
@@ -81,12 +80,6 @@ export const router = async event => {
       break;
     case 'saveFile':
       return await saveFile(eventData.filename, eventData.dataType, eventData.content);
-    case 'chooseFiles':
-      return await chooseFiles(
-        eventData.allowsMultipleSelection,
-        eventData.acceptTypes,
-        eventData.callbackId
-      );
     case 'copy':
       await copyToClipboardBridge(eventData.s);
       break;
@@ -142,10 +135,6 @@ const buildBridgeScript = () => {
     reloadIITC: ['clearCache'],
   };
 
-  const asyncEvents = {
-    chooseFiles: ['allowsMultipleSelection', 'acceptTypes'],
-  };
-
   // regular sync bridge functions
   Object.entries(events).forEach(entry => {
     const [key, value] = entry;
@@ -166,38 +155,6 @@ const buildBridgeScript = () => {
     'window.nsWebViewBridge.getVersionName = function() {return window.__iitcVersionName;};\n';
   bridge +=
     'window.nsWebViewBridge.showZoom = function() {return window.__iitcShowZoom === true;};\n';
-
-  // async callback-based bridge functions
-  Object.entries(asyncEvents).forEach(entry => {
-    const [key, value] = entry;
-    bridge +=
-      'window.nsWebViewBridge.' +
-      key +
-      ' = function(' +
-      value.join(', ') +
-      ', callback) {' +
-      " var callbackId = 'cb_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);" +
-      ' window._bridgeCallbacks = window._bridgeCallbacks || {};' +
-      " if (callback && typeof callback === 'function') { window._bridgeCallbacks[callbackId] = callback; }" +
-      " return window.nsWebViewBridge.emit('JSBridge', ['" +
-      key +
-      "', {" +
-      value.map(name => "'" + name + "': " + name).join(', ') +
-      (value.length > 0 ? ', ' : '') +
-      "'callbackId': callbackId}]); " +
-      '};\n';
-  });
-
-  // callback helper for async bridge functions
-  bridge +=
-    '// Helper to execute callback from native\n' +
-    'window.nsWebViewBridge._executeCallback = function(callbackId, result) {\n' +
-    '  if (window._bridgeCallbacks && window._bridgeCallbacks[callbackId]) {\n' +
-    '    var callback = window._bridgeCallbacks[callbackId];\n' +
-    '    delete window._bridgeCallbacks[callbackId];\n' +
-    '    callback(result);\n' +
-    '  }\n' +
-    '};\n';
 
   // Set window.app at the END, after all functions are defined
   bridge += 'window.app = window.nsWebViewBridge;\n';

--- a/app/utils/events-from-iitc.js
+++ b/app/utils/events-from-iitc.js
@@ -4,7 +4,7 @@ import store from '@/store';
 import { ApplicationSettings } from '@nativescript/core';
 import { strToBase64 } from 'lib-iitc-manager';
 import { showLocationShareOptions } from './share';
-import { shareFile, selectFiles, readFileContent } from '@/utils/file-manager';
+import { shareFile } from '@/utils/file-manager';
 import { copyToClipboard } from '@/utils/clipboard';
 import { shareContent } from '~/utils/platform';
 import { mapIcon } from './pane-icon-compat';
@@ -194,80 +194,6 @@ export const saveFile = async (filename, dataType, content) => {
   } catch (error) {
     console.error('Bridge saveFile error:', error);
     return { success: false, error: error.message };
-  }
-};
-
-/**
- * Handles file selection requests from IITC
- * @param {boolean} allowsMultipleSelection - Whether multiple file selection is allowed
- * @param {Array<string>} acceptTypes - Array of accepted MIME types
- * @param {string} callbackId - Callback ID for response
- * @returns {Promise<void>} Calls callback with File objects
- */
-export const chooseFiles = async (allowsMultipleSelection, acceptTypes, callbackId) => {
-  try {
-    const files = await selectFiles({
-      allowsMultipleSelection: allowsMultipleSelection || false,
-      acceptTypes: acceptTypes || ['*/*'],
-    });
-
-    // Read file contents
-    const fileContents = await Promise.all(
-      files.map(async file => {
-        try {
-          const content = await readFileContent(file.path);
-          return {
-            name: content.name,
-            content: content.content,
-            type: content.type,
-          };
-        } catch (error) {
-          console.error('Failed to read file:', file.path, error);
-          return null;
-        }
-      })
-    );
-
-    // Filter out failed reads
-    const validFiles = fileContents.filter(f => f !== null);
-
-    // Execute callback with File objects
-    if (callbackId) {
-      const callbackCode = `
-        if (window.app._executeCallback) {
-          var fileObjects = [];
-          ${validFiles
-            .map(
-              (file, index) => `
-          var blob${index} = new Blob([${JSON.stringify(file.content)}], { type: '${file.type}' });
-          var file${index} = new File([blob${index}], '${file.name}', {
-            type: '${file.type}',
-            lastModified: Date.now()
-          });
-          fileObjects.push(file${index});
-          `
-            )
-            .join('')}
-          window.nsWebViewBridge._executeCallback('${callbackId}', fileObjects);
-        }
-      `;
-
-      await store.dispatch('map/executeJavaScript', callbackCode);
-    }
-  } catch (error) {
-    console.error('Bridge chooseFiles error:', error);
-
-    // Execute callback with empty array on error
-    if (callbackId) {
-      await store.dispatch(
-        'map/executeJavaScript',
-        `
-        if (window.nsWebViewBridge._executeCallback) {
-          window.nsWebViewBridge._executeCallback('${callbackId}', []);
-        }
-      `
-      );
-    }
   }
 };
 

--- a/app/utils/file-manager.ts
+++ b/app/utils/file-manager.ts
@@ -1,104 +1,107 @@
+// Copyright (C) 2025-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+
 import { knownFolders } from '@nativescript/core';
 import * as fs from '@nativescript/core';
 import { ShareFile } from '@nativescript-community/ui-share-file';
 import { openFilePicker } from '@nativescript-community/ui-document-picker';
 
 export interface FileInfo {
-    name: string;
-    path: string;
-    type?: string;
-    size?: number;
+  name: string;
+  path: string;
+  type?: string;
+  size?: number;
 }
 
 export interface FileChooserParams {
-    allowsMultipleSelection?: boolean;
-    acceptTypes?: string[];
+  allowsMultipleSelection?: boolean;
+  acceptTypes?: string[];
 }
 
 export async function selectFiles(params: FileChooserParams): Promise<FileInfo[]> {
-    try {
-        const options: any = {
-            multipleSelection: params.allowsMultipleSelection || false,
-            copyToAppDocuments: true
-        };
+  try {
+    const options: any = {
+      multipleSelection: params.allowsMultipleSelection || false,
+      copyToAppDocuments: true,
+    };
 
-        if (params.acceptTypes?.length && !params.acceptTypes.includes('*/*')) {
-            options.mimeTypes = params.acceptTypes;
-        }
-
-        const result = await openFilePicker(options);
-
-        if (result.files?.length) {
-            const files = result.files.map((filePath: string) => {
-                const fileName = filePath.split('/').pop() || 'unknown';
-                return {
-                    name: fileName,
-                    path: filePath,
-                    type: 'text/plain',
-                    size: 0
-                };
-            });
-
-            return files;
-        }
-
-        return [];
-    } catch (error) {
-        console.error('File selection error:', error);
-        return [];
+    if (params.acceptTypes?.length && !params.acceptTypes.includes('*/*')) {
+      options.mimeTypes = params.acceptTypes;
     }
+
+    const result = await openFilePicker(options);
+
+    if (result.files?.length) {
+      const files = result.files.map((filePath: string) => {
+        const fileName = filePath.split('/').pop() || 'unknown';
+        return {
+          name: fileName,
+          path: filePath,
+          type: 'text/plain',
+          size: 0,
+        };
+      });
+
+      return files;
+    }
+
+    return [];
+  } catch (error) {
+    console.error('File selection error:', error);
+    return [];
+  }
 }
 
-export async function readFileContent(filePath: string): Promise<{ content: string; name: string; type: string }> {
-    try {
-        const file = fs.File.fromPath(filePath);
-        const content = await file.readText();
+export async function readFileContent(
+  filePath: string
+): Promise<{ content: string; name: string; type: string }> {
+  try {
+    const file = fs.File.fromPath(filePath);
+    const content = await file.readText();
 
-        // Extract filename from path
-        let fileName = filePath.split('/').pop() || 'unknown';
-        if (fileName.includes('%3A')) {
-            try {
-                fileName = decodeURIComponent(fileName);
-            } catch (e) {
-                // Keep original filename if decoding fails
-            }
-        }
-
-        return {
-            content: content,
-            name: fileName,
-            type: 'text/plain'
-        };
-
-    } catch (error) {
-        console.error('Error reading file content:', error);
-        throw error;
+    // Extract filename from path
+    let fileName = filePath.split('/').pop() || 'unknown';
+    if (fileName.includes('%3A')) {
+      try {
+        fileName = decodeURIComponent(fileName);
+      } catch (e) {
+        // Keep original filename if decoding fails
+      }
     }
+
+    return {
+      content: content,
+      name: fileName,
+      type: 'text/plain',
+    };
+  } catch (error) {
+    console.error('Error reading file content:', error);
+    throw error;
+  }
 }
 
 export async function shareFile(filename: string, content: string): Promise<void> {
-    try {
-        const tempDir = knownFolders.temp();
-        const sanitizedFilename = sanitizeFilename(filename);
-        const tempFile = tempDir.getFile(sanitizedFilename);
+  try {
+    const tempDir = knownFolders.temp();
+    const sanitizedFilename = sanitizeFilename(filename);
+    const tempFile = tempDir.getFile(sanitizedFilename);
 
-        await tempFile.writeText(content, 'utf8');
+    await tempFile.writeText(content);
 
-        const shareFile = new ShareFile();
-        await shareFile.open({
-            path: tempFile.path,
-            title: `Save ${filename}`,
-            options: true,
-            animated: true
-        });
+    const shareFile = new ShareFile();
+    await shareFile.open({
+      path: tempFile.path,
+      title: `Save ${filename}`,
+      options: true,
+      animated: true,
+    });
 
-        console.log('File exported:', filename);
-    } catch (error) {
-        console.error('Share file error:', error);
-        throw error;
-    }
+    console.log('File exported:', filename);
+  } catch (error) {
+    console.error('Share file error:', error);
+    throw error;
+  }
 }
 
 function sanitizeFilename(filename: string): string {
-    return filename.replace(/[<>:"/\\|?*]/g, '_').substring(0, 255);
+  return filename.replace(/[<>:"/\\|?*]/g, '_').substring(0, 255);
 }

--- a/app/utils/iitc-prime-resources.js
+++ b/app/utils/iitc-prime-resources.js
@@ -34,31 +34,3 @@ export const injectCustomStyles = async webview => {
     console.error('[injectCustomStyles] Failed to inject CSS:', error);
   }
 };
-
-/**
- * Override IITC's file chooser to use native file picker
- * @remarks After IITC boot (ui/iitcBootFinished)
- */
-export const installFileChooserOverride = async webview => {
-  const fileImportOverride = `(function() {
-  if (typeof L !== 'undefined' && L.FileReader && L.FileReader._chooseFiles) {
-    var originalChooseFiles = L.FileReader._chooseFiles;
-    L.FileReader._chooseFiles = function(callback, options) {
-      try {
-        window.app.chooseFiles(
-          options.multiple || false,
-          options.accept ? [options.accept] : ['*/*'],
-          callback
-        );
-      } catch (error) {
-        console.error('IITC-Prime: File chooser error', error);
-        if (callback) callback([]);
-      }
-    };
-  } else {
-    console.log('IITC-Prime: L.FileReader._chooseFiles not available yet');
-  }
-})();`;
-
-  await webview.executeJavaScript(fileImportOverride);
-};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@bezlepkin/nativescript-keyboard-opening": "^1.0.1",
-    "@modos189/nativescript-webview-x": "^1.1.0",
+    "@modos189/nativescript-webview-x": "^1.1.1",
     "@nativescript-community/fonticon": "^3.0.0",
     "@nativescript-community/gps": "^3.1.10",
     "@nativescript-community/l": "^4.3.10",


### PR DESCRIPTION
- Replace the `installFileChooserOverride` JS hack with proper Android `onShowFileChooser` support implemented in the webview-x plugin
- iOS `<input type="file">` works natively via WKWebView; add the required `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, and `NSPhotoLibraryUsageDescription` to Info.plist - WKWebView always shows Camera and Photo Library in the picker sheet regardless of the `accept` attribute, and the app crashes without these keys if the user taps them
- Remove the `chooseFiles` bridge method and all async callback machinery
- Fix iOS `saveFile`: `writeText(content, 'utf8')` passed a string where NativeScript expects a numeric `NSStringEncoding`, causing error; omitting the argument defaults to UTF-8 on both platforms