### PR TITLE
fix(webview): correct popup navigation, deep links and Intel page detection

### DIFF
--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -35,7 +35,7 @@ import {
   PLUGINS_READY_FLAG,
 } from '@/utils/manager/plugin-scripts';
 import BaseWebView from './BaseWebView.vue';
-import { addViewportParam, INGRESS_INTEL_MAP, isIntelUrl } from '@/utils/url-config';
+import { addViewportParam, isIntelUrl } from '@/utils/url-config';
 import { isIOS, isAndroid, Utils } from '@nativescript/core';
 import { webviewService } from '@/utils/webview/webview-service';
 
@@ -143,7 +143,7 @@ export default {
       }
 
       try {
-        if (arg.url.startsWith(INGRESS_INTEL_MAP)) {
+        if (isIntelUrl(arg.url)) {
           // Mark this URL as pending injection; onLoadFinished will inject only for this URL
           this.pendingInjectionUrl = urlWithoutHash;
           this.lastInjectedUrl = null;
@@ -159,7 +159,7 @@ export default {
     async onLoadFinished(arg) {
       // Two-step reload: wait for about:blank before loading the OAuth callback URL.
       // Ensures the hash causes a full cross-document load instead of a same-document navigation.
-      if (this.pendingReloadUrl && !arg?.url?.startsWith(INGRESS_INTEL_MAP)) {
+      if (this.pendingReloadUrl && !isIntelUrl(arg?.url)) {
         const url = this.pendingReloadUrl;
         this.pendingReloadUrl = null;
         this.lastInjectedUrl = null; // OAuth URL has a hash; reset so the check above won't skip it
@@ -168,7 +168,7 @@ export default {
       }
 
       // Only process Intel pages
-      if (!arg?.url || !arg.url.startsWith(INGRESS_INTEL_MAP)) {
+      if (!isIntelUrl(arg?.url)) {
         return;
       }
 

--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -35,7 +35,7 @@ import {
   PLUGINS_READY_FLAG,
 } from '@/utils/manager/plugin-scripts';
 import BaseWebView from './BaseWebView.vue';
-import { addViewportParam, INGRESS_INTEL_MAP } from '@/utils/url-config';
+import { addViewportParam, INGRESS_INTEL_MAP, isIntelUrl } from '@/utils/url-config';
 import { isIOS, isAndroid, Utils } from '@nativescript/core';
 import { webviewService } from '@/utils/webview/webview-service';
 
@@ -113,7 +113,7 @@ export default {
 
   methods: {
     handlePopupNavigate(url) {
-      if (url && url.startsWith(INGRESS_INTEL_MAP)) {
+      if (isIntelUrl(url)) {
         this.$store.dispatch('ui/reloadWebView', url);
       }
     },

--- a/app/components/BaseWebView.vue
+++ b/app/components/BaseWebView.vue
@@ -19,6 +19,7 @@
 <script>
 import { isAndroid } from '@nativescript/core';
 import { applyWebViewSettings } from '@/utils/webview/webview-settings';
+import { isIntelUrl, isExternalAppSchemeUrl } from '@/utils/url-config';
 import { getBaseUserAgent, getFakeDesktopUserAgent } from '@/utils/webview/user-agent';
 import { alert as customAlert, confirm as customConfirm } from '@/utils/dialogs';
 import { mapState } from 'vuex';
@@ -142,6 +143,9 @@ export default {
         if (isIntelUrl(url)) {
           args.cancel = true;
           this.$emit('popup-navigate', url);
+        } else if (isExternalAppSchemeUrl(url)) {
+          args.cancel = true;
+          this.$emit('external-url', url);
         }
       });
     },

--- a/app/components/BaseWebView.vue
+++ b/app/components/BaseWebView.vue
@@ -133,11 +133,13 @@ export default {
         this.$emit('bridge-message', ['gmBridgeRequest', msg.data]);
       });
 
-      // Intercept popup navigations: cancel (close popup) only for internal hostnames
-      // so OAuth flows navigate freely and only the callback redirect is handed to the host.
+      // Popup navigations stay in the popup, except two cases:
+      // any intel.ingress.com URL (matched by host goes to the main WebView,
+      // and app-scheme deep links (tg:, mailto:, ...) go to the OS
       this.webViewInstance.on('popupNavigate', args => {
         const url = args.url;
-        if (url && url !== 'about:blank' && !url.startsWith('file://') && this.isUrlAllowed(url)) {
+        if (!url || url === 'about:blank' || url.startsWith('file://')) return;
+        if (isIntelUrl(url)) {
           args.cancel = true;
           this.$emit('popup-navigate', url);
         }

--- a/app/utils/url-config.js
+++ b/app/utils/url-config.js
@@ -10,6 +10,46 @@ export const INITIAL_INTERNAL_HOSTNAMES = [
   'signin.nianticspatial.com',
 ];
 
+// Schemes a WebView renders itself; anything else is an app/deep link
+// (tg:, mailto:, geo:, ...) that must be handed to the OS instead of loaded.
+const WEBVIEW_SCHEMES = new Set([
+  'http',
+  'https',
+  'about',
+  'file',
+  'data',
+  'blob',
+  'javascript',
+  'x-local',
+]);
+
+/**
+ * True if the URL points at the Intel map host
+ * @param {string} url
+ * @returns {boolean}
+ */
+export const isIntelUrl = url => {
+  if (!url) return false;
+  try {
+    return new URL(url).hostname === 'intel.ingress.com';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * True for URLs whose scheme points at an external app (deep link) rather than web
+ * content the WebView can display.
+ * @param {string} url
+ * @returns {boolean}
+ */
+export const isExternalAppSchemeUrl = url => {
+  if (!url) return false;
+  const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(url);
+  if (!match) return false;
+  return !WEBVIEW_SCHEMES.has(match[1].toLowerCase());
+};
+
 /**
  * Add viewport parameter to URL for desktop/mobile mode switching
  * vp=f enables desktop mode, vp=m is the default mobile view


### PR DESCRIPTION
Fixes popup-based authentication and related WebView navigation:

- Keep OAuth popups open for safelisted hosts - addInternalHostname() no longer closes the popup mid-flow. Only intel.ingress.com is pulled into the main WebView; other web links stay in the popup. fix https://github.com/IITC-CE/IITC-Prime/issues/113
- Open app/deep-link schemes (tg:, mailto:, ...) from popups via the OS instead of showing an error page.
- Detect the Intel map page by host, not the /intel path: the map is also served at the site root where an OAuth callback returns, which previously left the status bar stuck on "Loading...".
