### PR TITLE
fix(webview): prevent intermittent double plugin injection on cold start

### DIFF
--- a/app/components/AppWebView.vue
+++ b/app/components/AppWebView.vue
@@ -28,11 +28,9 @@ import { injectCustomStyles } from '~/utils/iitc-prime-resources';
 import { injectDebugBridge, writeDebugBridgeFile } from '@/utils/bridge/debug-bridge';
 import {
   deletePluginScriptFile,
-  writePluginsMarkerFile,
   readPluginScriptCode,
   pluginScriptName,
-  PLUGINS_MARKER_NAME,
-  PLUGINS_READY_FLAG,
+  PLUGINS_INJECTED_MAP,
 } from '@/utils/manager/plugin-scripts';
 import BaseWebView from './BaseWebView.vue';
 import { addViewportParam, isIntelUrl } from '@/utils/url-config';
@@ -196,14 +194,9 @@ export default {
           }
         }
 
-        // Flag is set by the trailing marker user script after all plugins ran.
-        // Not set on cold start (manager not ready yet before first load).
-        const pluginsReady = await this.webview.executeJavaScript(
-          `window.${PLUGINS_READY_FLAG} === true`
-        );
-        if (pluginsReady !== true) {
-          await this.injectEnabledPlugins();
-        }
+        // Inject only plugins a pre-registered script didn't run; the per-file
+        // guard no-ops a redundant inject when injection timing races the load.
+        await this.injectEnabledPlugins();
 
         this.lastInjectedUrl = urlWithoutHash;
         this.pendingInjectionUrl = null;
@@ -311,11 +304,6 @@ export default {
           await webview.autoLoadJavaScriptFile(pluginScriptName(uid), filePath);
         }
 
-        // Marker last, so it runs after every plugin.
-        const markerPath = await writePluginsMarkerFile();
-        webview.removeAutoLoadJavaScriptFile(PLUGINS_MARKER_NAME);
-        await webview.autoLoadJavaScriptFile(PLUGINS_MARKER_NAME, markerPath);
-
         this.registeredPluginUids = newUids;
       } catch (error) {
         console.error('[AppWebView] Failed to register plugin scripts:', error);
@@ -338,8 +326,24 @@ export default {
     },
 
     async injectEnabledPlugins() {
+      // uids already run on this load.
+      const injectedJson = await this.webview.executeJavaScript(
+        `JSON.stringify(Object.keys(window.${PLUGINS_INJECTED_MAP}||{}))`
+      );
+      const injected = new Set(JSON.parse(injectedJson || '[]'));
+
+      // Fast path: all pre-registered plugins already ran -> skip the worker call.
+      // registeredPluginUids is empty before pre-registration, so fall through.
+      if (
+        this.registeredPluginUids.length &&
+        this.registeredPluginUids.every(uid => injected.has(uid))
+      ) {
+        return;
+      }
+
       const scripts = await this.$store.dispatch('manager/getEnabledPluginScripts');
       for (const script of scripts) {
+        if (injected.has(script.uid)) continue;
         await this.injectPlugin(script);
       }
     },

--- a/app/utils/manager/plugin-scripts.js
+++ b/app/utils/manager/plugin-scripts.js
@@ -4,22 +4,31 @@ import { File, knownFolders, path } from '@nativescript/core';
 import { sanitizeFileName } from 'lib-iitc-manager';
 
 const PLUGINS_DIR = 'iitc-plugins';
-const MARKER_FILENAME = 'iitc-plugins-ready.js';
 
-// Registered last, after all plugin scripts, so the load-finish fallback can
-// tell whether the pre-registered plugins ran (skips live inject to avoid
-// double-injecting the non-idempotent IITC core).
-export const PLUGINS_MARKER_NAME = 'iitcPluginsReady';
-export const PLUGINS_READY_FLAG = '__iitcPluginsReady';
+// Per-document map of uids already run; AppWebView reads it to skip re-injecting.
+export const PLUGINS_INJECTED_MAP = '__iitcInjected';
 
 const pluginsFolder = () => knownFolders.documents().getFolder(PLUGINS_DIR);
 const pluginFilePath = uid => path.join(pluginsFolder().path, `${sanitizeFileName(uid)}.js`);
 
 export const pluginScriptName = uid => `iitcPlugin:${uid}`;
 
+// Idempotency guard so an injection-timing race can't run a userscript twice:
+// the first injection path to run claims the uid, the other no-ops.
+// Block-wrapping is safe - injected code is always an IIFE/expression.
+const guard = uid => {
+  const key = JSON.stringify(uid);
+  const map = `window.${PLUGINS_INJECTED_MAP}`;
+  return {
+    open: `${map}=${map}||{};if(!${map}[${key}]){${map}[${key}]=true;\n`,
+    close: '\n}',
+  };
+};
+
 export const writePluginScriptFile = async (uid, code) => {
   const filePath = pluginFilePath(uid);
-  await File.fromPath(filePath).writeText(code);
+  const { open, close } = guard(uid);
+  await File.fromPath(filePath).writeText(open + code + close);
   return filePath;
 };
 
@@ -30,10 +39,4 @@ export const deletePluginScriptFile = async uid => {
   if (File.exists(filePath)) {
     await File.fromPath(filePath).remove();
   }
-};
-
-export const writePluginsMarkerFile = async () => {
-  const filePath = path.join(knownFolders.documents().path, MARKER_FILENAME);
-  await File.fromPath(filePath).writeText(`window.${PLUGINS_READY_FLAG} = true;`);
-  return filePath;
 };


### PR DESCRIPTION
## Problem
Userscripts could inject twice on cold start (e.g. Draw Tools toolbars appearing twice) - reported on iOS, intermittent after a few restarts.

## Cause
A single trailing marker script flagged the load-finish fallback to skip live injection. If a navigation commit landed after the userscripts registered but before the marker, they ran while the flag stayed unset, so the fallback re-injected everything - running each userscript twice. The same timing gap can occur on Android, where pre-registered scripts run asynchronously.

## Fix
Replace the all-or-nothing marker with a per-uid idempotency guard wrapped around each script: the first injection path to run claims the uid, the other no-ops. Each script runs once regardless of injection-vs-navigation timing, on both platforms.