### PR TITLE
feat(ui): adapt status bar and panel button to map theme

### DIFF
--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -37,7 +37,7 @@
     <key>UIStatusBarStyle</key>
     <string>UIStatusBarStyleLightContent</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
-    <false/>
+    <true/>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
       <string>armv7</string>

--- a/app/components/Main.vue
+++ b/app/components/Main.vue
@@ -50,13 +50,18 @@
         <MDRipple
           v-if="isPanelHidden && !isDebugActive"
           class="fab restore-panel-button"
-          :style="{ marginBottom: systemBottomInset + 16, marginRight: safeAreaRightInset + 16 }"
+          :style="{
+            marginBottom: systemBottomInset + 16,
+            marginRight: safeAreaRightInset + 16,
+            backgroundColor: fabBackgroundColor,
+          }"
           @loaded="onRestoreButtonLoaded"
           @tap="restorePanel"
         >
           <Label
             class="fa"
             :text="$filters.fonticon('fa-chevron-up')"
+            :color="fabIconColor"
             horizontalAlignment="center"
             verticalAlignment="center"
           />
@@ -90,7 +95,7 @@ import { keyboardOpening } from '@bezlepkin/nativescript-keyboard-opening';
 import { layoutService } from '~/utils/layout-service';
 import UserLocation from '@/utils/user-location';
 import { handleDeepLink } from '@/utils/deep-links';
-import { parseAndroidInsets } from '@/utils/platform/ui';
+import { parseAndroidInsets, setStatusBarForMapTheme } from '@/utils/platform/ui';
 
 import { $navigateTo } from 'nativescript-vue';
 import AppWebView from './AppWebView';
@@ -141,6 +146,21 @@ export default {
     isPanelHidden() {
       return this.$store.state.ui.panelState.position === 'HIDDEN';
     },
+    isMapDark() {
+      return this.$store.state.ui.isMapDark;
+    },
+    // Non-map panes render dark content over the map, so they always need light icons;
+    // otherwise the status bar follows the map theme.
+    isStatusBarDark() {
+      return this.$store.state.navigation.currentPane !== 'map' ? true : this.isMapDark;
+    },
+    // Restore-panel button
+    fabIconColor() {
+      return this.isMapDark ? '#111111' : '#eeeeee';
+    },
+    fabBackgroundColor() {
+      return this.isMapDark ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.3)';
+    },
     safeAreaLeftInset() {
       return this.$store.state.ui.screenSafeArea.left;
     },
@@ -175,6 +195,10 @@ export default {
   watch: {
     isPanelHidden(hidden) {
       this.updateMapStateBarVisibility(hidden, true);
+    },
+    isStatusBarDark(isDark) {
+      if (!this.isMainPageActive()) return;
+      setStatusBarForMapTheme(isDark);
     },
     '$store.state.ui.pendingPlugin'(pending) {
       if (pending) {
@@ -377,6 +401,15 @@ export default {
 
     onMainPageNavigatedTo() {
       this.$store.dispatch('ui/setMainPageFocused', true);
+      // Restore the status bar style after returning from another screen
+      setStatusBarForMapTheme(this.isStatusBarDark);
+    },
+
+    // Android EdgeToEdge resets the status bar to its default on every resume
+    onAppResume() {
+      if (this.isMainPageActive()) {
+        setStatusBarForMapTheme(this.isStatusBarDark);
+      }
     },
 
     onMainPageNavigatingFrom() {
@@ -434,6 +467,8 @@ export default {
     // Initialize deep link handling
     handleDeepLink();
 
+    Application.on(Application.resumeEvent, this.onAppResume);
+
     this.unsubscribeStore = this.$store.subscribeAction({
       after: async action => {
         switch (action.type) {
@@ -465,6 +500,8 @@ export default {
     if (this.userLocation) {
       this.userLocation.stopTracking();
     }
+
+    Application.off(Application.resumeEvent, this.onAppResume);
   },
 };
 </script>

--- a/app/components/Settings/SettingsBase.vue
+++ b/app/components/Settings/SettingsBase.vue
@@ -3,6 +3,7 @@
 <template>
   <Page
     actionBarHidden="true"
+    statusBarStyle="light"
     @navigatedTo="onNavigatedTo"
     @navigatedFrom="onNavigatedFrom"
     androidOverflowEdge="dont-apply"

--- a/app/store/modules/ui.js
+++ b/app/store/modules/ui.js
@@ -39,6 +39,9 @@ export const ui = {
 
     isKeyboardOpen: false,
 
+    // Active base map theme
+    isMapDark: true,
+
     isMainPageFocused: true,
 
     // Pending plugin to install (from file intent or URL)
@@ -124,6 +127,10 @@ export const ui = {
 
     SET_KEYBOARD_OPEN(state, isOpen) {
       state.isKeyboardOpen = isOpen;
+    },
+
+    SET_MAP_DARK(state, isDark) {
+      state.isMapDark = isDark;
     },
 
     SET_PENDING_PLUGIN(state, plugin) {
@@ -226,6 +233,10 @@ export const ui = {
 
     setKeyboardOpen({ commit }, isOpen) {
       commit('SET_KEYBOARD_OPEN', isOpen);
+    },
+
+    setMapDarkMode({ commit }, isDark) {
+      commit('SET_MAP_DARK', !!isDark);
     },
 
     setPendingPlugin({ commit }, plugin) {

--- a/app/utils/bridge/events-from-iitc.js
+++ b/app/utils/bridge/events-from-iitc.js
@@ -181,6 +181,14 @@ export const setFollowMode = async follow => {
 };
 
 /**
+ * Handles base map theme changes from IITC
+ * @param {boolean} isDark - Whether the active base map is dark-themed
+ */
+export const setMapDarkMode = async isDark => {
+  await store.dispatch('ui/setMapDarkMode', isDark);
+};
+
+/**
  * Handles file save requests from IITC
  * @param {string} filename - Name of the file to save
  * @param {string} dataType - MIME type of the file

--- a/app/utils/bridge/index.js
+++ b/app/utils/bridge/index.js
@@ -15,6 +15,7 @@ import {
   setActiveHighlighter,
   addInternalHostname,
   setFollowMode,
+  setMapDarkMode,
   saveFile,
   copyToClipboardBridge,
   shareString,
@@ -78,6 +79,9 @@ export const router = async event => {
     case 'setFollowMode':
       await setFollowMode(eventData.follow);
       break;
+    case 'setMapDarkMode':
+      await setMapDarkMode(eventData.isDark);
+      break;
     case 'saveFile':
       return await saveFile(eventData.filename, eventData.dataType, eventData.content);
     case 'copy':
@@ -117,6 +121,7 @@ const buildBridgeScript = () => {
     setActiveHighlighter: ['name'],
     addPane: ['name', 'label', 'icon'],
     setFollowMode: ['follow'],
+    setMapDarkMode: ['isDark'],
     setPortalStatus: [
       'guid',
       'team',

--- a/app/utils/platform/ui.js
+++ b/app/utils/platform/ui.js
@@ -1,6 +1,6 @@
 // Copyright (C) 2021-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
-import { Application, Utils, isAndroid, isIOS } from '@nativescript/core';
+import { Application, Frame, Utils, isAndroid, isIOS } from '@nativescript/core';
 
 /**
  * Get status bar height in DIP (Android only, fallback for when insets not yet dispatched)
@@ -32,6 +32,30 @@ export const getNavigationBarHeight = () => {
   return Utils.layout.toDeviceIndependentPixels(
     activity.getResources().getDimensionPixelSize(resourceId)
   );
+};
+
+/**
+ * Set status bar icon contrast for content shown over the map.
+ * The nav bar overlays the dark panel and is left untouched.
+ * @param {boolean} isDark - Whether the underlying content is dark (use light icons)
+ */
+export const setStatusBarForMapTheme = isDark => {
+  if (isAndroid) {
+    const activity = Application.android.foregroundActivity || Application.android.startActivity;
+    const window = activity?.getWindow();
+    if (!window) return;
+    const controller = androidx.core.view.WindowCompat.getInsetsController(
+      window,
+      window.getDecorView()
+    );
+    controller.setAppearanceLightStatusBars(!isDark);
+  } else if (isIOS) {
+    const page = Frame.topmost()?.currentPage;
+    if (!page) return;
+    page.statusBarStyle = isDark ? 'light' : 'dark';
+    // Setting the property doesn't invalidate the status bar appearance; force it.
+    page.updateStatusBar?.();
+  }
 };
 
 /**


### PR DESCRIPTION
Handles the `setMapDarkMode` bridge event introduced by https://github.com/IITC-CE/ingress-intel-total-conversion/pull/924, which fires whenever the base map layer changes.

- Status bar icon contrast switches automatically (light icons on dark maps, dark on light)
- Restore-panel FAB color updates to match the current map theme; always uses light icons when the panel is open (panel background is always dark)
